### PR TITLE
Add tenancy-check CI workflow

### DIFF
--- a/.github/workflows/tenancy.yml
+++ b/.github/workflows/tenancy.yml
@@ -1,0 +1,32 @@
+name: Tenancy Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tenancy-check:
+    name: Run tenancy-check.mjs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tenancy check
+        env:
+          DATABASE_URL: ${{ secrets.TENANCY_CHECK_DATABASE_URL }}
+        run: node scripts/tenancy-check.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,12 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Schema changes
+
+When introducing a new domain table that is scoped per-user, you **must** add it to the table list in `scripts/tenancy-check.mjs` so the isolation/null-user-id check covers it.
+
+The `Tenancy Check` GitHub Actions workflow (`.github/workflows/tenancy.yml`) runs `node scripts/tenancy-check.mjs` on every PR to `main`. Merges should be blocked if it fails — this is enforced via branch protection on `main`, which must be configured manually in repo settings (Settings → Branches → Branch protection rules → require status check `tenancy-check`).
+
+The `TENANCY_CHECK_DATABASE_URL` repo secret should point at a **non-prod Neon branch**, never the production database.
+


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/tenancy.yml` which runs `node scripts/tenancy-check.mjs` on every PR to `main`.
- Uses pnpm 9 + Node 24 with `pnpm install --frozen-lockfile`.
- Pulls `DATABASE_URL` from the repo secret `TENANCY_CHECK_DATABASE_URL`.
- Documents the convention in `AGENTS.md`: new per-user domain tables must be added to the script's table list, and the CI gate runs on every PR.

## Manual setup required

Two things have to be configured by hand in repo settings — CI alone won't enforce them:

1. **Add the secret `TENANCY_CHECK_DATABASE_URL`** at https://github.com/calvinmoltbot/relist-saas/settings/secrets/actions — this MUST point at a **non-prod Neon branch**, never the production database. The script connects and reads from it on every PR.
2. **Enable branch protection on `main`** at https://github.com/calvinmoltbot/relist-saas/settings/branches — add a rule for `main` and require the `Run tenancy-check.mjs` status check to pass before merging. Without this, the check runs but isn't blocking.

## Test plan

- [ ] Add `TENANCY_CHECK_DATABASE_URL` secret pointing at a non-prod Neon branch
- [ ] Confirm the workflow runs on this PR and reports pass/fail status
- [ ] Enable branch protection on `main` requiring the tenancy check
- [ ] Verify a follow-up PR is blocked from merging if the check fails

Closes #5