### PR TITLE
Add user_settings table for per-user configurable targets

### DIFF
--- a/drizzle/0004_calm_sentinel.sql
+++ b/drizzle/0004_calm_sentinel.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "user_settings" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"key" text NOT NULL,
+	"value" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "user_settings_user_key_idx" ON "user_settings" USING btree ("user_id","key");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,991 @@
+{
+  "id": "d6040344-13a1-4e93-b1a6-538ebf3fb447",
+  "prevId": "41304c0a-a939-434e-a599-42c1c047e3d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incurred_at": {
+          "name": "incurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_incurred_idx": {
+          "name": "expenses_user_incurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_category_idx": {
+          "name": "expenses_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_price": {
+          "name": "listed_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sourced'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'vinted'"
+        },
+        "photo_urls": {
+          "name": "photo_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinted_url": {
+          "name": "vinted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buyer_paid_shipping": {
+          "name": "buyer_paid_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_at": {
+          "name": "last_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relist_count": {
+          "name": "relist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_user_status_idx": {
+          "name": "items_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_brand_idx": {
+          "name": "items_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_category_idx": {
+          "name": "items_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_created_idx": {
+          "name": "items_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_listed_idx": {
+          "name": "items_user_listed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sold_idx": {
+          "name": "items_user_sold_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sold_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_data": {
+      "name": "price_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_minor": {
+          "name": "price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_data_user_observed_idx": {
+          "name": "price_data_user_observed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_brand_idx": {
+          "name": "price_data_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_source_external_idx": {
+          "name": "price_data_user_source_external_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_stats": {
+      "name": "price_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_size": {
+          "name": "sample_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_minor": {
+          "name": "median_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p25_minor": {
+          "name": "p25_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p75_minor": {
+          "name": "p75_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_minor": {
+          "name": "mean_minor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_stats_user_bucket_idx": {
+          "name": "price_stats_user_bucket_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_price": {
+          "name": "gross_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_cost": {
+          "name": "shipping_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "platform_fees": {
+          "name": "platform_fees",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "profit": {
+          "name": "profit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_item_idx": {
+          "name": "transactions_user_item_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_completed_idx": {
+          "name": "transactions_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_item_id_items_id_fk": {
+          "name": "transactions_item_id_items_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_key_idx": {
+          "name": "user_settings_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777703094285,
       "tag": "0003_bouncy_mockingbird",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777721546206,
+      "tag": "0004_calm_sentinel",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/tenancy-check.mjs
+++ b/scripts/tenancy-check.mjs
@@ -28,7 +28,7 @@ const ak = await sql`
 console.table(ak);
 
 console.log("\n=== Isolation check: any row with NULL user_id? ===");
-for (const t of ["price_data", "items", "transactions", "expenses", "api_keys"]) {
+for (const t of ["price_data", "items", "transactions", "expenses", "api_keys", "user_settings"]) {
   const r = await sql.query(`SELECT count(*)::int AS n FROM "${t}" WHERE user_id IS NULL`);
   console.log(`  ${t}: ${r[0].n} null-user rows`);
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -19,6 +19,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <Link href="/expenses">Expenses</Link>
           <Link href="/settings/api-keys">API keys</Link>
           <Link href="/settings/backup">Backup</Link>
+          <Link href="/settings/targets">Targets</Link>
         </nav>
         <UserButton />
       </header>

--- a/src/app/(app)/settings/targets/actions.ts
+++ b/src/app/(app)/settings/targets/actions.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { setTargets, type Targets } from "@/lib/settings";
+
+function parseField(value: FormDataEntryValue | null): number | undefined {
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n <= 0) return undefined;
+  return n;
+}
+
+export async function saveTargetsAction(formData: FormData): Promise<void> {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Not signed in");
+
+  const next: Partial<Targets> = {
+    staleListingDays: parseField(formData.get("staleListingDays")),
+    refreshSuggestedDays: parseField(formData.get("refreshSuggestedDays")),
+    weeklyListingsTarget: parseField(formData.get("weeklyListingsTarget")),
+  };
+
+  await setTargets(userId, next);
+  revalidatePath("/settings/targets");
+}

--- a/src/app/(app)/settings/targets/page.tsx
+++ b/src/app/(app)/settings/targets/page.tsx
@@ -1,0 +1,82 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getTargets, TARGET_DEFAULTS } from "@/lib/settings";
+import { saveTargetsAction } from "./actions";
+
+export default async function TargetsSettingsPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/");
+
+  const targets = await getTargets(userId);
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Targets</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Tune the thresholds that drive your daily plan and health report.
+          Defaults work for most sellers — adjust if your cadence or stock
+          turnover is different.
+        </p>
+      </header>
+
+      <form action={saveTargetsAction} className="space-y-5 rounded-md border p-4">
+        <Field
+          name="staleListingDays"
+          label="Stale listing (days)"
+          help={`Listings older than this show up in the daily reprice lane. Default ${TARGET_DEFAULTS.staleListingDays}.`}
+          defaultValue={targets.staleListingDays}
+        />
+        <Field
+          name="refreshSuggestedDays"
+          label="Refresh suggested (days)"
+          help={`How long a listing can sit before health flags it as dead stock. Default ${TARGET_DEFAULTS.refreshSuggestedDays}.`}
+          defaultValue={targets.refreshSuggestedDays}
+        />
+        <Field
+          name="weeklyListingsTarget"
+          label="Weekly listings target"
+          help={`The cadence pace your health report compares against. Default ${TARGET_DEFAULTS.weeklyListingsTarget}.`}
+          defaultValue={targets.weeklyListingsTarget}
+        />
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            className="rounded-md bg-black px-4 py-2 text-sm text-white"
+          >
+            Save targets
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  name,
+  label,
+  help,
+  defaultValue,
+}: {
+  name: string;
+  label: string;
+  help: string;
+  defaultValue: number;
+}) {
+  return (
+    <label className="block">
+      <span className="text-sm font-medium">{label}</span>
+      <input
+        type="number"
+        name={name}
+        min={1}
+        step={1}
+        defaultValue={defaultValue}
+        className="mt-1 block w-32 rounded-md border px-3 py-2 text-sm"
+        required
+      />
+      <span className="mt-1 block text-xs text-gray-500">{help}</span>
+    </label>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -187,3 +187,21 @@ export const apiKeys = pgTable(
   },
   (t) => [index("api_keys_user_idx").on(t.userId)],
 );
+
+export const userSettings = pgTable(
+  "user_settings",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    userId: text("user_id").notNull(),
+    key: text("key").notNull(),
+    value: text("value").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("user_settings_user_key_idx").on(t.userId, t.key),
+  ],
+);

--- a/src/lib/analytics/daily-plan.ts
+++ b/src/lib/analytics/daily-plan.ts
@@ -1,9 +1,7 @@
 import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items } from "@/db/schema";
-
-// Constants — restored from a user_settings table later.
-const STALE_LISTING_DAYS = 2;
+import { getTargets } from "@/lib/settings";
 
 export type TaskType = "ship" | "update" | "reprice" | "photo";
 
@@ -29,7 +27,8 @@ const gbp0 = (s: string | null) => (s ? `£${parseFloat(s).toFixed(0)}` : "");
 
 export async function buildDailyPlan(userId: string): Promise<DailyPlan> {
   const now = new Date();
-  const staleCutoff = new Date(now.getTime() - STALE_LISTING_DAYS * 86_400_000);
+  const { staleListingDays } = await getTargets(userId);
+  const staleCutoff = new Date(now.getTime() - staleListingDays * 86_400_000);
 
   const [soldItems, incompleteItems, staleItems, noPhotoItems] = await Promise.all([
     db

--- a/src/lib/analytics/health.ts
+++ b/src/lib/analytics/health.ts
@@ -3,13 +3,9 @@ import { db } from "@/db/client";
 import { items } from "@/db/schema";
 import { computeCadence, type CadenceResult } from "@/lib/inventory/cadence";
 import { scoreItem, summarise, type CompletenessSummary } from "@/lib/inventory/completeness";
+import { getTargets } from "@/lib/settings";
 
 const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
-
-// Targets — until user_settings table lands these are constants. The legacy
-// app loaded them from a key/value table; we'll restore that with daily-plan.
-const WEEKLY_LISTINGS_TARGET = 10;
-const REFRESH_SUGGESTED_DAYS = 7;
 
 export type HealthReport = Awaited<ReturnType<typeof computeHealth>>;
 
@@ -17,6 +13,7 @@ export async function computeHealth(userId: string) {
   const now = new Date();
   const fourWeeksAgo = new Date(now);
   fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 35);
+  const { weeklyListingsTarget, refreshSuggestedDays } = await getTargets(userId);
 
   // Pull the active inventory (listed + sourced) plus recent listed timestamps
   // for cadence. One round-trip via union of conditions keeps this cheap.
@@ -40,7 +37,7 @@ export async function computeHealth(userId: string) {
     .filter((d): d is Date => d != null && d.getTime() >= fourWeeksAgo.getTime());
   const cadence: CadenceResult = computeCadence(
     recentListedAts,
-    WEEKLY_LISTINGS_TARGET,
+    weeklyListingsTarget,
     now,
   );
 
@@ -92,7 +89,7 @@ export async function computeHealth(userId: string) {
     buckets[bucket] += 1;
     bucketValues[bucket] += value;
     if (days >= 15) stockAtRisk += value;
-    if (days >= REFRESH_SUGGESTED_DAYS && r.status === "listed") {
+    if (days >= refreshSuggestedDays && r.status === "listed") {
       deadStock.push({
         id: r.id,
         name: r.name,

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -7,6 +7,7 @@ import {
   expenses,
   items,
   transactions,
+  userSettings,
 } from "@/db/schema";
 
 type NewPriceData = typeof priceData.$inferInsert;
@@ -209,5 +210,21 @@ export function userScope(userId: string) {
         .from(transactions)
         .where(and(eq(transactions.userId, userId), eq(transactions.itemId, itemId)))
         .orderBy(desc(transactions.createdAt)),
+
+    listUserSettings: () =>
+      db
+        .select({ key: userSettings.key, value: userSettings.value })
+        .from(userSettings)
+        .where(eq(userSettings.userId, userId)),
+
+    setUserSetting: (key: string, value: string) =>
+      db
+        .insert(userSettings)
+        .values({ userId, key, value })
+        .onConflictDoUpdate({
+          target: [userSettings.userId, userSettings.key],
+          set: { value, updatedAt: new Date() },
+        })
+        .returning(),
   };
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,74 @@
+import { userScope } from "@/lib/db/scoped";
+
+/**
+ * Per-user configurable analytics targets. Defaults are the historical
+ * constants — used when the user hasn't set a row yet.
+ */
+export const TARGET_DEFAULTS = {
+  staleListingDays: 2,
+  refreshSuggestedDays: 7,
+  weeklyListingsTarget: 10,
+} as const;
+
+export type Targets = {
+  staleListingDays: number;
+  refreshSuggestedDays: number;
+  weeklyListingsTarget: number;
+};
+
+const KEYS = {
+  staleListingDays: "stale_listing_days",
+  refreshSuggestedDays: "refresh_suggested_days",
+  weeklyListingsTarget: "weekly_listings_target",
+} as const;
+
+type SettingKey = keyof typeof KEYS;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value == null) return fallback;
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return n;
+}
+
+export async function getSettings(userId: string): Promise<Record<string, string>> {
+  const rows = await userScope(userId).listUserSettings();
+  const out: Record<string, string> = {};
+  for (const r of rows) out[r.key] = r.value;
+  return out;
+}
+
+export async function getTargets(userId: string): Promise<Targets> {
+  const settings = await getSettings(userId);
+  return {
+    staleListingDays: parsePositiveInt(
+      settings[KEYS.staleListingDays],
+      TARGET_DEFAULTS.staleListingDays,
+    ),
+    refreshSuggestedDays: parsePositiveInt(
+      settings[KEYS.refreshSuggestedDays],
+      TARGET_DEFAULTS.refreshSuggestedDays,
+    ),
+    weeklyListingsTarget: parsePositiveInt(
+      settings[KEYS.weeklyListingsTarget],
+      TARGET_DEFAULTS.weeklyListingsTarget,
+    ),
+  };
+}
+
+export async function setTargets(
+  userId: string,
+  targets: Partial<Targets>,
+): Promise<void> {
+  const scope = userScope(userId);
+  const updates: Array<Promise<unknown>> = [];
+  for (const k of Object.keys(targets) as SettingKey[]) {
+    const v = targets[k];
+    if (v == null) continue;
+    if (!Number.isFinite(v) || v <= 0) continue;
+    updates.push(scope.setUserSetting(KEYS[k], String(v)));
+  }
+  await Promise.all(updates);
+}
+
+export const SETTING_KEYS = KEYS;


### PR DESCRIPTION
## Summary
- New `user_settings` key/value table scoped by `user_id`, plus drizzle migration `0004_calm_sentinel.sql` (additive only).
- `getTargets(userId)` / `setTargets(userId, …)` helpers in `src/lib/settings.ts` returning typed `staleListingDays`, `refreshSuggestedDays`, `weeklyListingsTarget` defaulted to the previous constants.
- `src/lib/analytics/health.ts` and `src/lib/analytics/daily-plan.ts` now load these values via the helper instead of module-level constants. No other analytics logic changed.
- New `/settings/targets` page with a Server Action (`saveTargetsAction`) mutation. Defaults populate the form when no row exists.
- `userScope(...)` gains `listUserSettings` and `setUserSetting` helpers (with a unique-key upsert).
- `scripts/tenancy-check.mjs` updated to assert no `user_settings` row has a NULL `user_id`.
- Nav link added in the (app) layout.

Closes #4

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint <changed-files>` clean
- [x] `pnpm db:generate` produced only the new `user_settings` table; migration applied with `pnpm db:migrate`
- [x] `bash -c 'set -a; source .env.local; set +a; node scripts/tenancy-check.mjs'` exits 0 and reports `user_settings: 0 null-user rows`
- [ ] Visit `/settings/targets`, change a value, save, reload; confirm it persists. Visit `/health` and `/plan` and confirm the new threshold takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)