### PR TITLE
Switch sign-up gating to Clerk Invitations

### DIFF
--- a/.github/workflows/tenancy.yml
+++ b/.github/workflows/tenancy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tenancy.yml
+++ b/.github/workflows/tenancy.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,13 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 When introducing a new domain table that is scoped per-user, you **must** add it to the table list in `scripts/tenancy-check.mjs` so the isolation/null-user-id check covers it.
 
-The `Tenancy Check` GitHub Actions workflow (`.github/workflows/tenancy.yml`) runs `node scripts/tenancy-check.mjs` on every PR to `main`. Merges should be blocked if it fails — this is enforced via branch protection on `main`, which must be configured manually in repo settings (Settings → Branches → Branch protection rules → require status check `tenancy-check`).
+The `Tenancy Check` GitHub Actions workflow (`.github/workflows/tenancy.yml`) runs `node scripts/tenancy-check.mjs` on every PR to `main`. Branch protection on `main` requires the `Run tenancy-check.mjs` status check to pass — merges are blocked if it fails.
 
-The `TENANCY_CHECK_DATABASE_URL` repo secret should point at a **non-prod Neon branch**, never the production database.
+The `TENANCY_CHECK_DATABASE_URL` repo secret should point at a **non-prod Neon branch**, never the production database. After applying a Drizzle migration to prod, also run `pnpm db:migrate` against the CI branch so the tenancy check has the latest schema to scan.
+
+## Sign-up access
+
+Sign-up is **invite-only**. Public sign-up is disabled in the Clerk dashboard, and the marketing page does not surface a sign-up CTA — only sign-in plus a note explaining access is by invitation.
+
+To grant access, send a Clerk Invitation from the dashboard (Users → Invitations → Invite). Do not re-introduce a public `/sign-up` route, a `<SignUp />` component, or a `SignUpButton` without a deliberate decision to open registration.
 

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
-import { SignInButton, SignUpButton, UserButton } from "@clerk/nextjs";
+import { SignInButton, UserButton } from "@clerk/nextjs";
 
 export default async function MarketingPage() {
   const { userId } = await auth();
@@ -21,9 +21,13 @@ export default async function MarketingPage() {
             <UserButton />
           </>
         ) : (
-          <div className="flex gap-3 [&_button]:rounded-md [&_button]:px-4 [&_button]:py-2 [&_button]:cursor-pointer [&_button]:border [&_button]:border-gray-300 [&_button]:bg-white [&_button]:text-gray-900 [&_button:hover]:bg-gray-50">
-            <SignInButton mode="modal" />
-            <SignUpButton mode="modal" />
+          <div className="space-y-3">
+            <div className="flex gap-3 [&_button]:rounded-md [&_button]:px-4 [&_button]:py-2 [&_button]:cursor-pointer [&_button]:border [&_button]:border-gray-300 [&_button]:bg-white [&_button]:text-gray-900 [&_button:hover]:bg-gray-50">
+              <SignInButton mode="modal" />
+            </div>
+            <p className="text-sm text-gray-500">
+              Access is invite-only. Ask Calvin for an invite link.
+            </p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Removes `SignUpButton` from the marketing landing page; only `SignInButton` remains, with an "Access is invite-only" note
- Adds a *Sign-up access* section to `AGENTS.md` documenting the invitation-only policy
- Updates the tenancy-check status check name in `AGENTS.md` to match what's actually configured in branch protection (`Run tenancy-check.mjs`)
- PRD updated separately at `~/shared/markviewer/relist-saas/2026-05-02-prd.md` §5 to reflect the policy change (allowlist → invitations)

## Manual step required
This PR is the **code half** of the gate. The other half is in the Clerk dashboard:

1. Clerk dashboard → User & Authentication → **Restrictions** (or Sign-up settings, depending on dashboard version)
2. **Disable public sign-up.** From this point on, the only path to a new account is a Clerk Invitation.

To invite a user: Clerk dashboard → **Users → Invitations → Invite** → enter email. Clerk emails the link.

## Why
The PRD originally assumed Clerk's allowlist feature, which is Pro-tier. The project is on free Clerk and constrained by a $5/month total infra cap. Invitations are free and offer the same Calvin-grants-access UX with slightly different mechanics (email link instead of allowlisted email).

## Test plan
- [ ] In Clerk dashboard, confirm public sign-up is disabled
- [ ] Visit the production landing page logged out — no "Sign up" button visible, only "Sign in" + the invite-only note
- [ ] Send yourself a Clerk Invitation to a fresh email — confirm the link works and creates an account
- [ ] Confirm there's still no `/sign-up` route reachable from the app

Closes #7