### PR TITLE
Ignore .claude agent worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 # pnpm
 .pnpm-store
 .env*.local
+
+# claude code agent worktrees
+.claude/


### PR DESCRIPTION
Adds `.claude/` to .gitignore so agent worktree directories don't show as untracked.