### PR TITLE
Add sample-data toggle in /settings (#13)

### DIFF
--- a/drizzle/0005_warm_forge.sql
+++ b/drizzle/0005_warm_forge.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "expenses" ADD COLUMN "is_sample" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "items" ADD COLUMN "is_sample" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "is_sample" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX "expenses_user_sample_idx" ON "expenses" USING btree ("user_id","is_sample");--> statement-breakpoint
+CREATE INDEX "items_user_sample_idx" ON "items" USING btree ("user_id","is_sample");--> statement-breakpoint
+CREATE INDEX "transactions_user_sample_idx" ON "transactions" USING btree ("user_id","is_sample");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1075 @@
+{
+  "id": "b8e235fe-ee62-4e79-9f15-80b4a7b177c2",
+  "prevId": "d6040344-13a1-4e93-b1a6-538ebf3fb447",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incurred_at": {
+          "name": "incurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_incurred_idx": {
+          "name": "expenses_user_incurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_category_idx": {
+          "name": "expenses_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_sample_idx": {
+          "name": "expenses_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_price": {
+          "name": "listed_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sourced'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'vinted'"
+        },
+        "photo_urls": {
+          "name": "photo_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinted_url": {
+          "name": "vinted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buyer_paid_shipping": {
+          "name": "buyer_paid_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_at": {
+          "name": "last_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relist_count": {
+          "name": "relist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_user_status_idx": {
+          "name": "items_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sample_idx": {
+          "name": "items_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_brand_idx": {
+          "name": "items_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_category_idx": {
+          "name": "items_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_created_idx": {
+          "name": "items_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_listed_idx": {
+          "name": "items_user_listed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sold_idx": {
+          "name": "items_user_sold_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sold_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_data": {
+      "name": "price_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_minor": {
+          "name": "price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_data_user_observed_idx": {
+          "name": "price_data_user_observed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_brand_idx": {
+          "name": "price_data_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_source_external_idx": {
+          "name": "price_data_user_source_external_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_stats": {
+      "name": "price_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_size": {
+          "name": "sample_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_minor": {
+          "name": "median_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p25_minor": {
+          "name": "p25_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p75_minor": {
+          "name": "p75_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_minor": {
+          "name": "mean_minor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_stats_user_bucket_idx": {
+          "name": "price_stats_user_bucket_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_price": {
+          "name": "gross_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_cost": {
+          "name": "shipping_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "platform_fees": {
+          "name": "platform_fees",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "profit": {
+          "name": "profit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_item_idx": {
+          "name": "transactions_user_item_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_completed_idx": {
+          "name": "transactions_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_sample_idx": {
+          "name": "transactions_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_item_id_items_id_fk": {
+          "name": "transactions_item_id_items_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_key_idx": {
+          "name": "user_settings_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777721546206,
       "tag": "0004_calm_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777825482317,
+      "tag": "0005_warm_forge",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -20,6 +20,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           <Link href="/settings/api-keys">API keys</Link>
           <Link href="/settings/backup">Backup</Link>
           <Link href="/settings/targets">Targets</Link>
+          <Link href="/settings/sample-data">Sample data</Link>
         </nav>
         <UserButton />
       </header>

--- a/src/app/(app)/settings/sample-data/actions.ts
+++ b/src/app/(app)/settings/sample-data/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { seedSampleData, clearSampleData } from "@/lib/sample-data";
+
+function revalidateAll() {
+  for (const p of [
+    "/settings/sample-data",
+    "/dashboard",
+    "/inventory",
+    "/profit",
+    "/health",
+    "/bestsellers",
+    "/plan",
+    "/expenses",
+    "/market",
+  ]) {
+    revalidatePath(p);
+  }
+}
+
+export async function loadSampleDataAction(): Promise<void> {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Not signed in");
+  await seedSampleData(userId);
+  revalidateAll();
+}
+
+export async function clearSampleDataAction(): Promise<void> {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Not signed in");
+  await clearSampleData(userId);
+  revalidateAll();
+}

--- a/src/app/(app)/settings/sample-data/page.tsx
+++ b/src/app/(app)/settings/sample-data/page.tsx
@@ -1,0 +1,64 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { hasSampleData } from "@/lib/sample-data";
+import { loadSampleDataAction, clearSampleDataAction } from "./actions";
+
+export default async function SampleDataSettingsPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/");
+
+  const hasSamples = await hasSampleData(userId);
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Sample data</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Populate your account with a small set of demo items, transactions,
+          and expenses so you can see how every page looks before adding any
+          real data. Clearing only removes the seeded rows — anything you
+          added yourself stays untouched.
+        </p>
+      </header>
+
+      <section className="rounded-md border p-4 space-y-4">
+        <div>
+          <h2 className="text-sm font-semibold">Status</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            {hasSamples
+              ? "Sample data is currently loaded in your account."
+              : "No sample data is currently loaded."}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          <form action={loadSampleDataAction}>
+            <button
+              type="submit"
+              disabled={hasSamples}
+              className="rounded-md bg-black px-4 py-2 text-sm text-white disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Load sample data
+            </button>
+          </form>
+
+          <form action={clearSampleDataAction}>
+            <button
+              type="submit"
+              disabled={!hasSamples}
+              className="rounded-md border border-gray-300 px-4 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Clear sample data
+            </button>
+          </form>
+        </div>
+
+        <p className="text-xs text-gray-500">
+          Loading seeds 8 items across a handful of brands and statuses
+          (sourced / listed / sold), their buy and sell transactions, and 2
+          expenses. Clear is safe — it only removes rows tagged as sample.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,6 +102,7 @@ export const items = pgTable(
     shippedAt: timestamp("shipped_at", { withTimezone: true }),
     lastEditedAt: timestamp("last_edited_at", { withTimezone: true }),
     relistCount: integer("relist_count").notNull().default(0),
+    isSample: boolean("is_sample").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -111,6 +112,7 @@ export const items = pgTable(
   },
   (t) => [
     index("items_user_status_idx").on(t.userId, t.status),
+    index("items_user_sample_idx").on(t.userId, t.isSample),
     index("items_user_brand_idx").on(t.userId, t.brand),
     index("items_user_category_idx").on(t.userId, t.category),
     index("items_user_created_idx").on(t.userId, t.createdAt),
@@ -137,6 +139,7 @@ export const transactions = pgTable(
       .default("0"),
     profit: numeric("profit", { precision: 10, scale: 2 }),
     completedAt: timestamp("completed_at", { withTimezone: true }),
+    isSample: boolean("is_sample").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -144,6 +147,7 @@ export const transactions = pgTable(
   (t) => [
     index("transactions_user_item_idx").on(t.userId, t.itemId),
     index("transactions_user_completed_idx").on(t.userId, t.completedAt),
+    index("transactions_user_sample_idx").on(t.userId, t.isSample),
   ],
 );
 
@@ -159,6 +163,7 @@ export const expenses = pgTable(
     amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
     itemId: text("item_id"), // FK added when items table lands; same-user enforced via userScope
     incurredAt: timestamp("incurred_at", { withTimezone: true }).notNull(),
+    isSample: boolean("is_sample").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -166,6 +171,7 @@ export const expenses = pgTable(
   (t) => [
     index("expenses_user_incurred_idx").on(t.userId, t.incurredAt),
     index("expenses_user_category_idx").on(t.userId, t.category),
+    index("expenses_user_sample_idx").on(t.userId, t.isSample),
   ],
 );
 

--- a/src/lib/sample-data.ts
+++ b/src/lib/sample-data.ts
@@ -1,0 +1,278 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { items, transactions, expenses } from "@/db/schema";
+
+type SampleItem = {
+  name: string;
+  brand: string;
+  category: string;
+  condition: "new" | "like_new" | "good" | "fair";
+  size: string;
+  costPrice: string;
+  listedPrice: string;
+  soldPrice?: string;
+  status: "sourced" | "listed" | "sold";
+  daysAgoCreated: number;
+  daysAgoListed?: number;
+  daysAgoSold?: number;
+  shippingCost?: string;
+  platformFees?: string;
+};
+
+const SAMPLES: SampleItem[] = [
+  {
+    name: "Nike Air Max 90",
+    brand: "Nike",
+    category: "Shoes",
+    condition: "good",
+    size: "UK 9",
+    costPrice: "12.00",
+    listedPrice: "45.00",
+    soldPrice: "42.00",
+    status: "sold",
+    daysAgoCreated: 30,
+    daysAgoListed: 28,
+    daysAgoSold: 4,
+    shippingCost: "3.50",
+    platformFees: "2.10",
+  },
+  {
+    name: "Zara Wool Coat",
+    brand: "Zara",
+    category: "Outerwear",
+    condition: "like_new",
+    size: "M",
+    costPrice: "20.00",
+    listedPrice: "55.00",
+    status: "listed",
+    daysAgoCreated: 10,
+    daysAgoListed: 9,
+  },
+  {
+    name: "Levi's 501 Jeans",
+    brand: "Levi's",
+    category: "Jeans",
+    condition: "good",
+    size: "W32 L32",
+    costPrice: "8.00",
+    listedPrice: "28.00",
+    soldPrice: "25.00",
+    status: "sold",
+    daysAgoCreated: 60,
+    daysAgoListed: 58,
+    daysAgoSold: 14,
+    shippingCost: "3.20",
+    platformFees: "1.25",
+  },
+  {
+    name: "Uniqlo Heattech Crew",
+    brand: "Uniqlo",
+    category: "Tops",
+    condition: "good",
+    size: "L",
+    costPrice: "3.00",
+    listedPrice: "12.00",
+    status: "listed",
+    daysAgoCreated: 21,
+    daysAgoListed: 20,
+  },
+  {
+    name: "H&M Floral Midi Dress",
+    brand: "H&M",
+    category: "Dresses",
+    condition: "like_new",
+    size: "S",
+    costPrice: "5.00",
+    listedPrice: "18.00",
+    status: "sourced",
+    daysAgoCreated: 2,
+  },
+  {
+    name: "Adidas Stan Smith",
+    brand: "Adidas",
+    category: "Shoes",
+    condition: "good",
+    size: "UK 8",
+    costPrice: "15.00",
+    listedPrice: "38.00",
+    status: "listed",
+    daysAgoCreated: 45,
+    daysAgoListed: 44,
+  },
+  {
+    name: "Ralph Lauren Polo",
+    brand: "Ralph Lauren",
+    category: "Tops",
+    condition: "good",
+    size: "M",
+    costPrice: "6.00",
+    listedPrice: "22.00",
+    soldPrice: "20.00",
+    status: "sold",
+    daysAgoCreated: 50,
+    daysAgoListed: 48,
+    daysAgoSold: 7,
+    shippingCost: "3.20",
+    platformFees: "1.00",
+  },
+  {
+    name: "Mango Trench Coat",
+    brand: "Mango",
+    category: "Outerwear",
+    condition: "new",
+    size: "S",
+    costPrice: "25.00",
+    listedPrice: "65.00",
+    status: "sourced",
+    daysAgoCreated: 1,
+  },
+];
+
+const SAMPLE_EXPENSES = [
+  {
+    category: "shipping_supplies",
+    description: "Polymailers + tissue paper",
+    amount: "15.40",
+    daysAgo: 12,
+  },
+  {
+    category: "packaging",
+    description: "Bubble wrap roll",
+    amount: "8.20",
+    daysAgo: 25,
+  },
+];
+
+function daysAgo(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d;
+}
+
+export async function hasSampleData(userId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: items.id })
+    .from(items)
+    .where(and(eq(items.userId, userId), eq(items.isSample, true)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+export async function seedSampleData(userId: string): Promise<{
+  items: number;
+  transactions: number;
+  expenses: number;
+}> {
+  if (await hasSampleData(userId)) {
+    return { items: 0, transactions: 0, expenses: 0 };
+  }
+
+  let itemCount = 0;
+  let txCount = 0;
+
+  for (const s of SAMPLES) {
+    const createdAt = daysAgo(s.daysAgoCreated);
+    const listedAt = s.daysAgoListed != null ? daysAgo(s.daysAgoListed) : null;
+    const soldAt = s.daysAgoSold != null ? daysAgo(s.daysAgoSold) : null;
+
+    const [row] = await db
+      .insert(items)
+      .values({
+        userId,
+        name: s.name,
+        brand: s.brand,
+        category: s.category,
+        condition: s.condition,
+        size: s.size,
+        costPrice: s.costPrice,
+        listedPrice: s.listedPrice,
+        soldPrice: s.soldPrice ?? null,
+        status: s.status,
+        platform: "vinted",
+        listedAt,
+        soldAt,
+        isSample: true,
+        createdAt,
+        updatedAt: createdAt,
+      })
+      .returning({ id: items.id });
+
+    itemCount++;
+
+    await db.insert(transactions).values({
+      userId,
+      itemId: row.id,
+      transactionType: "buy",
+      grossPrice: s.costPrice,
+      shippingCost: "0",
+      platformFees: "0",
+      profit: null,
+      completedAt: createdAt,
+      isSample: true,
+    });
+    txCount++;
+
+    if (s.status === "sold" && s.soldPrice && soldAt) {
+      const gross = parseFloat(s.soldPrice);
+      const ship = parseFloat(s.shippingCost ?? "0");
+      const fees = parseFloat(s.platformFees ?? "0");
+      const cost = parseFloat(s.costPrice);
+      const profit = (gross - ship - fees - cost).toFixed(2);
+
+      await db.insert(transactions).values({
+        userId,
+        itemId: row.id,
+        transactionType: "sell",
+        grossPrice: s.soldPrice,
+        shippingCost: s.shippingCost ?? "0",
+        platformFees: s.platformFees ?? "0",
+        profit,
+        completedAt: soldAt,
+        isSample: true,
+      });
+      txCount++;
+    }
+  }
+
+  let expenseCount = 0;
+  for (const e of SAMPLE_EXPENSES) {
+    await db.insert(expenses).values({
+      userId,
+      category: e.category,
+      description: e.description,
+      amount: e.amount,
+      incurredAt: daysAgo(e.daysAgo),
+      isSample: true,
+    });
+    expenseCount++;
+  }
+
+  return { items: itemCount, transactions: txCount, expenses: expenseCount };
+}
+
+export async function clearSampleData(userId: string): Promise<{
+  items: number;
+  transactions: number;
+  expenses: number;
+}> {
+  const txDeleted = await db
+    .delete(transactions)
+    .where(and(eq(transactions.userId, userId), eq(transactions.isSample, true)))
+    .returning({ id: transactions.id });
+
+  const expDeleted = await db
+    .delete(expenses)
+    .where(and(eq(expenses.userId, userId), eq(expenses.isSample, true)))
+    .returning({ id: expenses.id });
+
+  const itemDeleted = await db
+    .delete(items)
+    .where(and(eq(items.userId, userId), eq(items.isSample, true)))
+    .returning({ id: items.id });
+
+  return {
+    items: itemDeleted.length,
+    transactions: txDeleted.length,
+    expenses: expDeleted.length,
+  };
+}


### PR DESCRIPTION
## Summary
- New `/settings/sample-data` page with **Load** / **Clear** buttons
- Adds `is_sample` boolean column to `items`, `transactions`, `expenses` (Drizzle migration `0005_warm_forge.sql`)
- Seeder creates 8 items across brands/categories/statuses (sourced/listed/sold), their buy/sell transactions, and 2 expenses — enough to light up dashboard, inventory, profit, health, bestsellers, plan
- Clear path filters strictly on `is_sample = true` so user-entered rows are never touched
- Added `(user_id, is_sample)` indexes on all three tables
- No new domain tables → no `tenancy-check.mjs` change required

## Test plan
- [ ] Sign in as a fresh user, visit `/settings/sample-data`, click **Load sample data**
- [ ] Confirm `/dashboard`, `/inventory`, `/profit`, `/health`, `/bestsellers`, `/plan`, `/expenses` all show populated content
- [ ] Add a real item manually
- [ ] Click **Clear sample data** — verify the real item still exists, sample rows are gone
- [ ] Verify Load button is disabled while sample data is loaded; Clear is disabled when none present
- [ ] Run `pnpm db:migrate` against the CI Neon branch after merge

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)