### PR TITLE
Top-nav refactor + Dashboard rebuild

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,70 +1,92 @@
 import Link from "next/link";
+import Image from "next/image";
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { computeProfit } from "@/lib/analytics/profit";
+import { computeDashboardSparks } from "@/lib/analytics/dashboard-sparks";
 import { userScope } from "@/lib/db/scoped";
-import { FirstRunNudge } from "@/components/FirstRunNudge";
 import { hasSampleData } from "@/lib/sample-data";
+import { FirstRunNudge } from "@/components/FirstRunNudge";
+import {
+  ButtonLink,
+  Card,
+  CardHeader,
+  PageHeader,
+  Tile,
+} from "@/components/ui";
 import { clearSampleDataAction } from "./sample-data-actions";
 
 const gbp = (n: number) => `£${n.toFixed(2)}`;
+const num0 = (n: number) => n.toLocaleString("en-GB");
+const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
+
+function deltaPct(spark: number[]): { label: string; dir: "up" | "down" | "flat" } | null {
+  if (spark.length < 14) return null;
+  const half = Math.floor(spark.length / 2);
+  const recent = sum(spark.slice(half));
+  const prior = sum(spark.slice(0, half));
+  if (prior === 0 && recent === 0) return null;
+  if (prior === 0) return { label: "new", dir: "up" };
+  const change = ((recent - prior) / prior) * 100;
+  if (Math.abs(change) < 1) return { label: "±0%", dir: "flat" };
+  const sign = change > 0 ? "+" : "−";
+  return {
+    label: `${sign}${Math.abs(change).toFixed(1)}%`,
+    dir: change > 0 ? "up" : "down",
+  };
+}
 
 export default async function DashboardPage() {
   const { userId } = await auth();
   if (!userId) redirect("/");
 
-  // Headline = current month
   const now = new Date();
   const from = new Date(now.getFullYear(), now.getMonth(), 1);
   const to = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
-  const [month, allTime, itemCount, sampleLoaded] = await Promise.all([
+
+  const [month, allTime, itemCount, sampleLoaded, sparks] = await Promise.all([
     computeProfit(userId, { from, to }),
     computeProfit(userId, { from: null, to: null }),
     userScope(userId).countItems(),
     hasSampleData(userId),
+    computeDashboardSparks(userId),
   ]);
+
   const isFirstRun = itemCount === 0;
 
-  const tiles: Array<{ label: string; value: string; sub?: string }> = [
-    { label: "Revenue this month", value: gbp(month.summary.revenue), sub: `${month.summary.itemsSold} sold` },
-    { label: "Net profit this month", value: gbp(month.summary.netProfit), sub: `${month.summary.avgMargin}% avg margin` },
-    { label: "Stock value (listed)", value: gbp(allTime.summary.stockListedValue), sub: `${allTime.summary.itemsListed} listed` },
-    { label: "Items sourced", value: allTime.summary.itemsSourced.toString(), sub: "ready to list" },
-  ];
+  const revDelta = deltaPct(sparks.revenue);
+  const profitDelta = deltaPct(sparks.profit);
+  const stockDelta = deltaPct(sparks.listed);
+
+  const topThumbs = await Promise.all(
+    allTime.itemProfits.slice(0, 8).map(async (p) => ({
+      ...p,
+      thumb: await userScope(userId).getItemThumbnail(p.id),
+    })),
+  );
 
   return (
     <div className="space-y-8">
-      <header className="flex items-end justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Dashboard</h1>
-          <p className="mt-1 text-sm text-gray-600">
-            {now.toLocaleString("en-GB", { month: "long", year: "numeric" })}
-          </p>
-        </div>
-        <div className="flex gap-2 text-sm">
-          <Link href="/profit" className="rounded-md border px-3 py-1.5">
-            Profit
-          </Link>
-          <Link
-            href="/inventory/new"
-            className="rounded-md bg-black px-3 py-1.5 text-white"
-          >
-            Add item
-          </Link>
-        </div>
-      </header>
-
-      {isFirstRun && <FirstRunNudge />}
+      <PageHeader
+        title="Dashboard"
+        subtitle={now.toLocaleString("en-GB", { month: "long", year: "numeric" })}
+        actions={
+          <>
+            <ButtonLink href="/profit" variant="secondary" size="sm">Profit</ButtonLink>
+            <ButtonLink href="/inventory/new" size="sm">+ Add item</ButtonLink>
+          </>
+        }
+      />
 
       {sampleLoaded && (
-        <section className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
-          <span className="text-amber-900">
+        <section className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-md)] border border-[var(--accent-amber)]/30 bg-[var(--accent-amber-soft)] px-4 py-3 text-sm text-[var(--accent-amber-soft-fg)]">
+          <span>
             Sample data is loaded in your account. Clear it once you&apos;re ready to work with real items only.
           </span>
           <form action={clearSampleDataAction}>
             <button
               type="submit"
-              className="rounded-md border border-amber-300 bg-white px-3 py-1.5 text-amber-900"
+              className="rounded-[var(--radius-md)] border border-[var(--accent-amber)]/40 bg-white px-3 py-1.5 text-xs font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--surface-muted)]"
             >
               Clear sample data
             </button>
@@ -72,55 +94,177 @@ export default async function DashboardPage() {
         </section>
       )}
 
-      <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        {tiles.map((t) => (
-          <div key={t.label} className="rounded-md border p-4">
-            <div className="text-xs uppercase text-gray-500">{t.label}</div>
-            <div className="mt-1 text-2xl font-semibold">{t.value}</div>
-            {t.sub && <div className="mt-0.5 text-xs text-gray-500">{t.sub}</div>}
-          </div>
-        ))}
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Tile
+          label="Revenue this month"
+          value={gbp(month.summary.revenue)}
+          sub={`${month.summary.itemsSold} sold`}
+          tone="brand"
+          icon={<MoneyIcon />}
+          delta={revDelta?.label}
+          deltaDirection={revDelta?.dir}
+          spark={sparks.revenue}
+        />
+        <Tile
+          label="Net profit this month"
+          value={gbp(month.summary.netProfit)}
+          sub={`${month.summary.avgMargin}% avg margin`}
+          tone="emerald"
+          icon={<TrendIcon />}
+          delta={profitDelta?.label}
+          deltaDirection={profitDelta?.dir}
+          spark={sparks.profit}
+        />
+        <Tile
+          label="Stock value (listed)"
+          value={gbp(allTime.summary.stockListedValue)}
+          sub={`${allTime.summary.itemsListed} listed`}
+          tone="amber"
+          icon={<StackIcon />}
+          delta={stockDelta?.label}
+          deltaDirection={stockDelta?.dir}
+          spark={sparks.listed}
+        />
+        <Tile
+          label="Items sourced"
+          value={num0(allTime.summary.itemsSourced)}
+          sub="ready to list"
+          tone="violet"
+          icon={<PlusIcon />}
+          spark={sparks.sourced}
+        />
       </section>
 
-      <section>
-        <h2 className="text-sm font-medium text-gray-600">Top profit (lifetime)</h2>
-        {allTime.itemProfits.length === 0 ? (
-          <p className="mt-2 text-sm text-gray-500">
-            Nothing sold yet. Add items at{" "}
-            <Link href="/inventory/new" className="underline">
-              Inventory → New
-            </Link>
-            .
-          </p>
-        ) : (
-          <table className="mt-2 w-full border-collapse text-sm">
-            <thead>
-              <tr className="border-b text-left text-xs uppercase text-gray-500">
-                <th className="py-2 pr-4">Item</th>
-                <th className="py-2 pr-4">Brand</th>
-                <th className="py-2 pr-4 text-right">Sold</th>
-                <th className="py-2 pr-4 text-right">Net</th>
-              </tr>
-            </thead>
-            <tbody>
-              {allTime.itemProfits.slice(0, 8).map((p) => (
-                <tr key={p.id} className="border-b">
-                  <td className="py-2 pr-4">
-                    <Link href={`/inventory/${p.id}`} className="underline">
-                      {p.name}
-                    </Link>
-                  </td>
-                  <td className="py-2 pr-4">{p.brand ?? "—"}</td>
-                  <td className="py-2 pr-4 text-right">{gbp(p.sold)}</td>
-                  <td className="py-2 pr-4 text-right font-medium">
-                    {gbp(p.netProfit)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <Card padded={false}>
+            <div className="flex items-center justify-between p-5 pb-3">
+              <h2 className="font-display text-lg font-semibold">Top profit (lifetime)</h2>
+              <Link
+                href="/profit"
+                className="text-xs font-medium text-[var(--brand)] hover:underline"
+              >
+                View all →
+              </Link>
+            </div>
+            {topThumbs.length === 0 ? (
+              <p className="px-5 pb-5 text-sm text-[var(--text-muted)]">
+                Nothing sold yet. Add items at{" "}
+                <Link href="/inventory/new" className="text-[var(--brand)] underline">
+                  Inventory → New
+                </Link>
+                .
+              </p>
+            ) : (
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-y border-[var(--border-subtle)] bg-[var(--surface-muted)] text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                    <th className="py-2 pl-5 pr-3 font-medium">Item</th>
+                    <th className="py-2 pr-3 font-medium">Brand</th>
+                    <th className="py-2 pr-3 text-right font-medium">Sold</th>
+                    <th className="py-2 pr-5 text-right font-medium">Net</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topThumbs.map((p) => (
+                    <tr
+                      key={p.id}
+                      className="border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--surface-muted)]/60"
+                    >
+                      <td className="py-2.5 pl-5 pr-3">
+                        <Link href={`/inventory/${p.id}`} className="flex items-center gap-3">
+                          <span className="relative inline-flex h-9 w-9 shrink-0 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
+                            {p.thumb ? (
+                              <Image
+                                src={p.thumb}
+                                alt=""
+                                width={36}
+                                height={36}
+                                className="h-full w-full object-cover"
+                                unoptimized
+                              />
+                            ) : (
+                              <span className="m-auto text-[9px] uppercase text-[var(--text-muted)]">no img</span>
+                            )}
+                          </span>
+                          <span className="font-medium text-[var(--text-primary)] hover:underline">
+                            {p.name}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="py-2.5 pr-3 text-[var(--text-secondary)]">{p.brand ?? "—"}</td>
+                      <td className="py-2.5 pr-3 text-right tabular-nums">{gbp(p.sold)}</td>
+                      <td className="py-2.5 pr-5 text-right font-semibold tabular-nums text-[var(--accent-emerald-soft-fg)]">
+                        {gbp(p.netProfit)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </Card>
+        </div>
+
+        <div>
+          {isFirstRun ? (
+            <FirstRunNudge variant="panel" />
+          ) : (
+            <Card>
+              <CardHeader title="Quick actions" description="The fast path to common tasks." />
+              <ul className="mt-4 space-y-2 text-sm">
+                <ActionRow href="/inventory/new" label="Add a new item" />
+                <ActionRow href="/plan" label="See today's plan" />
+                <ActionRow href="/inventory?status=listed" label="Browse listed items" />
+                <ActionRow href="/expenses" label="Log an expense" />
+              </ul>
+            </Card>
+          )}
+        </div>
       </section>
     </div>
+  );
+}
+
+function ActionRow({ href, label }: { href: string; label: string }) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className="flex items-center justify-between rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-3 py-2 hover:bg-[var(--surface-muted)]"
+      >
+        <span className="text-[var(--text-primary)]">{label}</span>
+        <span className="text-[var(--text-muted)]" aria-hidden>›</span>
+      </Link>
+    </li>
+  );
+}
+
+/* ----- Icons (inline so we don't pull a lib) ----- */
+function MoneyIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M11 5.5C11 4.67 10.1 4 9 4S7 4.67 7 5.5 7.9 7 9 7s2 .67 2 1.5S10.1 10 9 10s-2-.67-2-1.5M9 3v1M9 10v1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+function TrendIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M3 14l4-4 3 3 5-6M11 7h4v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function StackIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M9 2L2 5.5l7 3.5 7-3.5L9 2zM2 9l7 3.5L16 9M2 12.5L9 16l7-3.5" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function PlusIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M9 4v10M4 9h10" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,29 +1,14 @@
-import Link from "next/link";
-import { UserButton } from "@clerk/nextjs";
+import { TopNav } from "@/components/nav/TopNav";
+import { MobileTabBar } from "@/components/nav/MobileTabBar";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="flex items-center justify-between border-b px-6 py-3">
-        <nav className="flex items-center gap-4 text-sm">
-          <Link href="/dashboard" className="font-semibold">Relist</Link>
-          <Link href="/dashboard">Dashboard</Link>
-          <Link href="/plan">Plan</Link>
-          <Link href="/inventory">Inventory</Link>
-          <Link href="/profit">Profit</Link>
-          <Link href="/bestsellers">Bestsellers</Link>
-          <Link href="/health">Health</Link>
-          <Link href="/market">Market</Link>
-          <Link href="/watch">Watch</Link>
-          <Link href="/describe">Describe</Link>
-          <Link href="/expenses">Expenses</Link>
-          <Link href="/settings/api-keys">API keys</Link>
-          <Link href="/settings/backup">Backup</Link>
-          <Link href="/settings/targets">Targets</Link>
-        </nav>
-        <UserButton />
-      </header>
-      <main className="flex-1 px-6 py-8">{children}</main>
+      <TopNav />
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 pb-24 pt-6 sm:px-6 lg:pb-12">
+        {children}
+      </main>
+      <MobileTabBar />
     </div>
   );
 }

--- a/src/app/(app)/menu/page.tsx
+++ b/src/app/(app)/menu/page.tsx
@@ -1,0 +1,79 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { PageHeader, Card } from "@/components/ui";
+
+const SECTIONS: Array<{
+  title: string;
+  items: Array<{ href: string; label: string; description: string }>;
+}> = [
+  {
+    title: "Analytics",
+    items: [
+      { href: "/bestsellers", label: "Bestsellers", description: "Which categories and brands sell fastest." },
+      { href: "/health", label: "Health", description: "Inventory freshness, completeness, dead stock." },
+      { href: "/market", label: "Market", description: "Competitor pricing data from your extension." },
+    ],
+  },
+  {
+    title: "Operations",
+    items: [
+      { href: "/expenses", label: "Expenses", description: "Packaging, shipping supplies, fees." },
+    ],
+  },
+  {
+    title: "Coming soon",
+    items: [
+      { href: "/watch", label: "Watch", description: "Bookmark items you're considering." },
+      { href: "/describe", label: "Describe", description: "AI-drafted listing copy (BYO key)." },
+    ],
+  },
+  {
+    title: "Settings",
+    items: [
+      { href: "/settings/api-keys", label: "API keys", description: "Tokens for the Chrome extension." },
+      { href: "/settings/backup", label: "Backup & restore", description: "Download or restore your data." },
+      { href: "/settings/targets", label: "Targets", description: "Tune thresholds for plan and health." },
+    ],
+  },
+];
+
+export default async function MenuPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/");
+
+  return (
+    <div className="space-y-8">
+      <PageHeader title="Menu" subtitle="Everything that doesn't live in the bottom tab bar." />
+      {SECTIONS.map((s) => (
+        <section key={s.title} className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            {s.title}
+          </h2>
+          <Card padded={false}>
+            <ul className="divide-y divide-[var(--border-subtle)]">
+              {s.items.map((it) => (
+                <li key={it.href}>
+                  <Link
+                    href={it.href}
+                    className="flex items-center justify-between gap-4 px-4 py-3 hover:bg-[var(--surface-muted)]"
+                  >
+                    <div>
+                      <div className="text-sm font-medium text-[var(--text-primary)]">
+                        {it.label}
+                      </div>
+                      <div className="text-xs text-[var(--text-secondary)]">
+                        {it.description}
+                      </div>
+                    </div>
+                    <span className="text-[var(--text-muted)]" aria-hidden>›</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/nav/MobileTabBar.tsx
+++ b/src/components/nav/MobileTabBar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { href: "/dashboard", label: "Dashboard", icon: HomeIcon },
+  { href: "/plan", label: "Plan", icon: PlanIcon },
+  { href: "/inventory", label: "Inventory", icon: InventoryIcon },
+  { href: "/profit", label: "Profit", icon: ProfitIcon },
+  { href: "/menu", label: "More", icon: MoreIcon },
+];
+
+export function MobileTabBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-[var(--border-subtle)] bg-[var(--surface-card)]/95 backdrop-blur lg:hidden">
+      <ul className="mx-auto flex max-w-2xl items-stretch justify-around">
+        {TABS.map(({ href, label, icon: Icon }) => {
+          const isActive = href === "/menu"
+            ? false
+            : pathname === href || pathname.startsWith(`${href}/`);
+          return (
+            <li key={href} className="flex-1">
+              <Link
+                href={href}
+                className={`flex flex-col items-center justify-center gap-1 px-1 pb-2 pt-2 text-[11px] font-medium ${
+                  isActive
+                    ? "text-[var(--brand)]"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <Icon active={isActive} />
+                <span>{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="h-[env(safe-area-inset-bottom)]" aria-hidden />
+    </nav>
+  );
+}
+
+type IconProps = { active?: boolean };
+const stroke = (active?: boolean) =>
+  active ? "var(--brand)" : "currentColor";
+
+function HomeIcon({ active }: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path d="M3 8.5L10 3l7 5.5V16a1 1 0 0 1-1 1h-3v-5H7v5H4a1 1 0 0 1-1-1V8.5Z" stroke={stroke(active)} strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function PlanIcon({ active }: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <rect x="3" y="4" width="14" height="13" rx="2" stroke={stroke(active)} strokeWidth="1.5" />
+      <path d="M3 8h14M7 3v3M13 3v3M6 12h4M6 15h6" stroke={stroke(active)} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+function InventoryIcon({ active }: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <rect x="3" y="3" width="6" height="6" rx="1" stroke={stroke(active)} strokeWidth="1.5" />
+      <rect x="11" y="3" width="6" height="6" rx="1" stroke={stroke(active)} strokeWidth="1.5" />
+      <rect x="3" y="11" width="6" height="6" rx="1" stroke={stroke(active)} strokeWidth="1.5" />
+      <rect x="11" y="11" width="6" height="6" rx="1" stroke={stroke(active)} strokeWidth="1.5" />
+    </svg>
+  );
+}
+function ProfitIcon({ active }: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path d="M3 16l5-5 3 3 6-7" stroke={stroke(active)} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M13 7h4v4" stroke={stroke(active)} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function MoreIcon({ active }: IconProps) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <circle cx="5" cy="10" r="1.5" fill={stroke(active)} />
+      <circle cx="10" cy="10" r="1.5" fill={stroke(active)} />
+      <circle cx="15" cy="10" r="1.5" fill={stroke(active)} />
+    </svg>
+  );
+}

--- a/src/components/nav/MoreMenu.tsx
+++ b/src/components/nav/MoreMenu.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+type Item = { href: string; label: string };
+
+export function MoreMenu({ items }: { items: Item[] }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
+      >
+        More
+        <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+          <path d="M3 4.5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-30 mt-2 w-48 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-2)]"
+        >
+          {items.map((it) => (
+            <Link
+              key={it.href}
+              href={it.href}
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              className="block px-3 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--surface-muted)]"
+            >
+              {it.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/nav/NavLink.tsx
+++ b/src/components/nav/NavLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type Props = {
+  href: string;
+  children: React.ReactNode;
+  /** If set, treat the link as active when the pathname starts with this prefix. */
+  matchPrefix?: string;
+};
+
+export function NavLink({ href, children, matchPrefix }: Props) {
+  const pathname = usePathname();
+  const isActive = matchPrefix
+    ? pathname.startsWith(matchPrefix)
+    : pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <Link
+      href={href}
+      className={`rounded-[var(--radius-md)] px-3 py-1.5 text-sm font-medium transition-colors ${
+        isActive
+          ? "bg-[var(--brand-soft)] text-[var(--brand-soft-fg)]"
+          : "text-[var(--text-secondary)] hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/nav/TopNav.tsx
+++ b/src/components/nav/TopNav.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { UserButton } from "@clerk/nextjs";
+import { MoreMenu } from "./MoreMenu";
+import { NavLink } from "./NavLink";
+
+const PRIMARY = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/plan", label: "Plan" },
+  { href: "/inventory", label: "Inventory" },
+  { href: "/profit", label: "Profit" },
+  { href: "/bestsellers", label: "Bestsellers" },
+  { href: "/health", label: "Health" },
+  { href: "/market", label: "Market" },
+];
+
+const MORE = [
+  { href: "/expenses", label: "Expenses" },
+  { href: "/watch", label: "Watch" },
+  { href: "/describe", label: "Describe" },
+];
+
+export function TopNav() {
+  return (
+    <header className="sticky top-0 z-20 border-b border-[var(--border-subtle)] bg-[var(--surface-card)]/80 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-7xl items-center gap-2 px-4 sm:px-6">
+        <Link
+          href="/dashboard"
+          className="font-display text-lg font-semibold tracking-tight text-[var(--text-primary)]"
+        >
+          Relist
+        </Link>
+
+        <nav className="ml-6 hidden items-center gap-1 lg:flex">
+          {PRIMARY.map((l) => (
+            <NavLink key={l.href} href={l.href}>{l.label}</NavLink>
+          ))}
+          <MoreMenu items={MORE} />
+          <NavLink href="/settings/api-keys" matchPrefix="/settings">Settings</NavLink>
+        </nav>
+
+        <div className="ml-auto flex items-center gap-3">
+          <UserButton appearance={{ elements: { avatarBox: "h-8 w-8" } }} />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/Tile.tsx
+++ b/src/components/ui/Tile.tsx
@@ -62,7 +62,7 @@ export function Tile({
         <div className="text-xs uppercase tracking-wide text-[var(--text-muted)]">
           {label}
         </div>
-        <div className="mt-1 font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)]">
+        <div className="mt-1 text-2xl font-semibold tracking-tight tabular-nums text-[var(--text-primary)] md:text-3xl">
           {value}
         </div>
         {sub && (

--- a/src/lib/analytics/dashboard-sparks.ts
+++ b/src/lib/analytics/dashboard-sparks.ts
@@ -1,0 +1,67 @@
+import { and, eq, gte } from "drizzle-orm";
+import { db } from "@/db/client";
+import { items } from "@/db/schema";
+
+const DAYS = 30;
+
+const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+
+/**
+ * Compute small daily series for the dashboard tile sparklines:
+ *   revenue   — sum of soldPrice on days items were sold (last 30d)
+ *   profit    — soldPrice minus costPrice on those same days
+ *   listed    — running count of items in `listed` status by listedAt date
+ *   sourced   — running count of items in `sourced` status by createdAt date
+ */
+export async function computeDashboardSparks(userId: string) {
+  const since = new Date();
+  since.setDate(since.getDate() - DAYS);
+
+  const rows = await db
+    .select({
+      status: items.status,
+      costPrice: items.costPrice,
+      soldPrice: items.soldPrice,
+      listedAt: items.listedAt,
+      soldAt: items.soldAt,
+      createdAt: items.createdAt,
+    })
+    .from(items)
+    .where(and(eq(items.userId, userId), gte(items.createdAt, since)));
+
+  const revenue = new Array(DAYS).fill(0) as number[];
+  const profit = new Array(DAYS).fill(0) as number[];
+  const listed = new Array(DAYS).fill(0) as number[];
+  const sourced = new Array(DAYS).fill(0) as number[];
+
+  const todayMidnight = new Date();
+  todayMidnight.setHours(0, 0, 0, 0);
+  const dayIndex = (d: Date | null) => {
+    if (!d) return -1;
+    const days = Math.floor((todayMidnight.getTime() - new Date(d).setHours(0, 0, 0, 0)) / 86400000);
+    const i = DAYS - 1 - days;
+    return i >= 0 && i < DAYS ? i : -1;
+  };
+
+  for (const r of rows) {
+    if (r.status === "sold" || r.status === "shipped") {
+      const i = dayIndex(r.soldAt);
+      if (i >= 0) {
+        const sold = num(r.soldPrice);
+        const cost = num(r.costPrice);
+        revenue[i] += sold;
+        profit[i] += sold - cost;
+      }
+    }
+    if (r.status === "listed") {
+      const i = dayIndex(r.listedAt);
+      if (i >= 0) listed[i] += 1;
+    }
+    if (r.status === "sourced") {
+      const i = dayIndex(r.createdAt);
+      if (i >= 0) sourced[i] += 1;
+    }
+  }
+
+  return { revenue, profit, listed, sourced };
+}


### PR DESCRIPTION
## Summary

First real visible payoff from the design system. Replaces the 15-link nav bar with a tighter primary nav, a More dropdown, a Settings group, and a mobile bottom-tab bar. Rebuilds the Dashboard to match \`02-dashboard.png\`.

### Nav (desktop, lg+)
\`\`\`
Relist | Dashboard · Plan · Inventory · Profit · Bestsellers · Health · Market
       | More ▾ (Expenses · Watch · Describe) · Settings | UserButton
\`\`\`
Active route gets a brand-soft pill background. \`Settings\` is active for any \`/settings/*\` path.

### Nav (mobile, <lg)
Sticky bottom tab bar — **Dashboard · Plan · Inventory · Profit · More**.
The More tab opens \`/menu\`, a grouped vertical list of every secondary page (Analytics / Operations / Coming Soon / Settings). Honours \`env(safe-area-inset-bottom)\` on iOS.

### Dashboard rebuild
- \`PageHeader\` with month + **Profit** / **+ Add item** actions
- **Four \`Tile\` metric cards** with toned icon chips, sparklines, and half-vs-half period-over-period deltas. The sparkline data comes from a new \`computeDashboardSparks(userId)\` helper that buckets the last 30 days of sold / listed / sourced activity per day.
- **Top profit (lifetime)** redone as a Card: thumbnail column, hover rows, *View all* link, tabular-nums prices, emerald-toned Net column
- **Quick actions** card on the right when there's data; FirstRunNudge \`panel\` variant takes its place for empty accounts
- **Sample-data clear banner** re-skinned to design-system tokens (no functional change)

No data-shape or schema changes — pure UI rebuild.

### Out of scope (next PRs)
- Inventory list rebuild (table + grid view, status pills, mobile cards)
- Item detail rebuild
- Profit / Health / Bestsellers
- Settings sub-nav (will appear when the Settings pages are themselves rebuilt)
- Landing page redesign

## Test plan
- [ ] Visit \`/dashboard\` — confirm tiles render with sparklines + deltas, top profit table has thumbnails
- [ ] Resize to <1024px — desktop nav hides, mobile bottom tab bar appears
- [ ] Tap **More** on mobile → \`/menu\` lists every secondary page
- [ ] Active state highlights as you navigate Dashboard / Plan / Inventory / Profit
- [ ] Click **More ▾** in desktop nav — dropdown shows Expenses / Watch / Describe; Esc and outside-click both close it
- [ ] First-run user with no items: right column shows the **welcome panel** instead of Quick actions
- [ ] Sample data loaded: amber banner appears and clear button works
- [ ] \`/design-system\` still renders correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)