### PR TITLE
Import Lily's backup + stop selecting photo blobs

### DIFF
--- a/scripts/import-from-lily.mjs
+++ b/scripts/import-from-lily.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Import a Relist (legacy single-tenant) JSON backup into the multi-tenant
+ * relist-saas DB under a chosen Clerk userId, with every row tagged
+ * is_sample = true so it can be cleared via the UI.
+ *
+ * READ-ONLY against the source backup file. Never touches Lily's app or DB.
+ *
+ * Usage:
+ *   node scripts/import-from-lily.mjs --backup <path-to-backup.json> --user-id <clerk_user_id>
+ *
+ * Optional flags:
+ *   --dry-run        parse + map but don't insert
+ *   --replace        delete this user's existing is_sample rows first
+ *
+ * Mapping notes:
+ * - vinted_url is dropped intentionally (no public links, per request)
+ * - photo_urls + thumbnail_url come through as-is (base64 data URIs)
+ * - new UUIDs are generated for items / transactions / expenses
+ * - timestamps preserved
+ */
+import { config } from "dotenv";
+import { neon } from "@neondatabase/serverless";
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+config({ path: ".env.local", quiet: true });
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || (!args["backup"] && !args["b"])) {
+  console.log(usage());
+  process.exit(args.help ? 0 : 1);
+}
+
+const backupPath = args.backup ?? args.b;
+const targetUserId = args["user-id"] ?? args.u;
+const dryRun = !!args["dry-run"];
+const replace = !!args.replace;
+
+if (!targetUserId) {
+  console.error("Missing --user-id. Available users with rows already in the DB:");
+  await printUserCandidates();
+  process.exit(1);
+}
+
+const sql = neon(process.env.DATABASE_URL);
+
+console.log(`→ reading ${backupPath}`);
+const raw = await readFile(backupPath, "utf8");
+const backup = JSON.parse(raw);
+const data = backup.data ?? {};
+const items = data.items ?? [];
+const transactions = data.transactions ?? [];
+const expenses = data.expenses ?? [];
+
+console.log(
+  `→ source: ${items.length} items, ${transactions.length} transactions, ${expenses.length} expenses`,
+);
+console.log(`→ target user: ${targetUserId}`);
+if (dryRun) console.log("→ DRY RUN — no writes");
+if (replace) console.log("→ will delete existing is_sample rows for this user first");
+
+// Build item id remap — old UUID → new UUID
+const itemIdMap = new Map();
+for (const it of items) itemIdMap.set(it.id, randomUUID());
+
+// Map items to relist-saas shape
+const itemsToInsert = items.map((it) => ({
+  id: itemIdMap.get(it.id),
+  user_id: targetUserId,
+  name: it.name,
+  brand: it.brand ?? null,
+  category: it.category ?? null,
+  condition: it.condition ?? null,
+  size: it.size ?? null,
+  cost_price: it.costPrice ?? null,
+  listed_price: it.listedPrice ?? null,
+  sold_price: it.soldPrice ?? null,
+  status: it.status ?? "sourced",
+  platform: it.platform ?? "vinted",
+  photo_urls: it.photoUrls ?? null,
+  thumbnail_url: it.thumbnailUrl ?? null,
+  description: it.description ?? null,
+  source_type: it.sourceType ?? null,
+  source_location: it.sourceLocation ?? null,
+  vinted_url: null, // intentionally dropped
+  listed_at: it.listedAt ?? null,
+  sold_at: it.soldAt ?? null,
+  buyer_paid_shipping: it.buyerPaidShipping ?? true,
+  shipped_at: it.shippedAt ?? null,
+  last_edited_at: it.lastEditedAt ?? null,
+  relist_count: it.relistCount ?? 0,
+  is_sample: true,
+  created_at: it.createdAt ?? new Date().toISOString(),
+  updated_at: it.updatedAt ?? new Date().toISOString(),
+}));
+
+const txToInsert = transactions
+  .filter((t) => itemIdMap.has(t.itemId))
+  .map((t) => ({
+    id: randomUUID(),
+    user_id: targetUserId,
+    item_id: itemIdMap.get(t.itemId),
+    transaction_type: t.transactionType,
+    gross_price: t.grossPrice ?? null,
+    shipping_cost: t.shippingCost ?? "0",
+    platform_fees: t.platformFees ?? "0",
+    profit: t.profit ?? null,
+    completed_at: t.completedAt ?? null,
+    is_sample: true,
+    created_at: t.createdAt ?? new Date().toISOString(),
+  }));
+
+const expToInsert = expenses.map((e) => ({
+  id: randomUUID(),
+  user_id: targetUserId,
+  category: e.category ?? "other",
+  description: e.description ?? null,
+  amount: e.amount ?? "0",
+  item_id: e.itemId && itemIdMap.has(e.itemId) ? itemIdMap.get(e.itemId) : null,
+  incurred_at: e.incurredAt ?? e.createdAt ?? new Date().toISOString(),
+  is_sample: true,
+  created_at: e.createdAt ?? new Date().toISOString(),
+}));
+
+console.log(
+  `→ mapped: ${itemsToInsert.length} items, ${txToInsert.length} transactions (${
+    transactions.length - txToInsert.length
+  } orphaned), ${expToInsert.length} expenses`,
+);
+
+if (dryRun) {
+  console.log("→ DRY RUN complete, no writes performed");
+  process.exit(0);
+}
+
+if (replace) {
+  console.log("→ deleting existing is_sample rows for this user…");
+  const t = await sql`DELETE FROM transactions WHERE user_id = ${targetUserId} AND is_sample = true RETURNING id`;
+  const x = await sql`DELETE FROM expenses WHERE user_id = ${targetUserId} AND is_sample = true RETURNING id`;
+  const i = await sql`DELETE FROM items WHERE user_id = ${targetUserId} AND is_sample = true RETURNING id`;
+  console.log(`  ↳ removed ${i.length} items, ${t.length} transactions, ${x.length} expenses`);
+}
+
+console.log("→ inserting items…");
+let n = 0;
+for (const batch of chunks(itemsToInsert, 20)) {
+  await bulkInsert("items", batch);
+  n += batch.length;
+  process.stdout.write(`  ${n}/${itemsToInsert.length}\r`);
+}
+console.log(`  ↳ ${n} items inserted`);
+
+console.log("→ inserting transactions…");
+n = 0;
+for (const batch of chunks(txToInsert, 50)) {
+  if (batch.length === 0) continue;
+  await bulkInsert("transactions", batch);
+  n += batch.length;
+}
+console.log(`  ↳ ${n} transactions inserted`);
+
+if (expToInsert.length > 0) {
+  console.log("→ inserting expenses…");
+  await bulkInsert("expenses", expToInsert);
+  console.log(`  ↳ ${expToInsert.length} expenses inserted`);
+}
+
+console.log("\n✓ done");
+
+// ------------------------------------------------------------------- helpers
+
+function* chunks(arr, n) {
+  for (let i = 0; i < arr.length; i += n) yield arr.slice(i, i + n);
+}
+
+/**
+ * Multi-row bulk insert via sql.query with $N placeholders, since
+ * @neondatabase/serverless tagged-template doesn't support row arrays.
+ */
+async function bulkInsert(table, rows) {
+  if (rows.length === 0) return;
+  const cols = Object.keys(rows[0]);
+  const colList = cols.map((c) => `"${c}"`).join(", ");
+  const params = [];
+  const valuesSql = rows
+    .map((row) => {
+      const placeholders = cols.map((c) => {
+        params.push(row[c]);
+        return `$${params.length}`;
+      });
+      return `(${placeholders.join(", ")})`;
+    })
+    .join(", ");
+  await sql.query(`INSERT INTO "${table}" (${colList}) VALUES ${valuesSql}`, params);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--") && !a.startsWith("-")) continue;
+    const key = a.replace(/^--?/, "");
+    const next = argv[i + 1];
+    if (next && !next.startsWith("-")) {
+      out[key] = next;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+function usage() {
+  return `Usage:
+  node scripts/import-from-lily.mjs --backup <path> --user-id <clerk_user_id> [--dry-run] [--replace]
+
+Examples:
+  node scripts/import-from-lily.mjs --backup ~/Dev/Projects/relist/backups/relist-20260424-072905.json --user-id user_xxx --dry-run
+  node scripts/import-from-lily.mjs --backup ~/Dev/Projects/relist/backups/relist-20260424-072905.json --user-id user_xxx --replace`;
+}
+
+async function printUserCandidates() {
+  const rows = await sql`
+    SELECT user_id, count(*)::int AS items
+    FROM items WHERE is_sample = false
+    GROUP BY user_id ORDER BY items DESC
+  `;
+  if (rows.length === 0) {
+    console.error("  (no users with non-sample items yet)");
+  } else {
+    console.table(rows);
+  }
+}

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
     if (!existing.listedPrice && data.listedPrice) updates.listedPrice = data.listedPrice;
     if (!existing.description && data.description) updates.description = data.description;
     if (!existing.vintedUrl && data.vintedUrl) updates.vintedUrl = data.vintedUrl;
-    if (data.photoUrls?.length && !existing.photoUrls?.length) {
+    if (data.photoUrls?.length && !existing.hasPhotos) {
       updates.photoUrls = data.photoUrls;
       if (data.thumbnailUrl && !existing.thumbnailUrl) updates.thumbnailUrl = data.thumbnailUrl;
     }

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -46,7 +46,19 @@ export async function computeBestsellers(userId: string, range: DateRange) {
   // Pull sold + shipped items in the user's scope; we filter by soldAt range
   // in JS so the schema's soldAt nullable case stays explicit.
   const rows = await db
-    .select()
+    .select({
+      id: items.id,
+      name: items.name,
+      brand: items.brand,
+      category: items.category,
+      sourceType: items.sourceType,
+      condition: items.condition,
+      size: items.size,
+      costPrice: items.costPrice,
+      soldPrice: items.soldPrice,
+      listedAt: items.listedAt,
+      soldAt: items.soldAt,
+    })
     .from(items)
     .where(
       and(
@@ -65,7 +77,11 @@ export async function computeBestsellers(userId: string, range: DateRange) {
   const ids = inRange.map((r) => r.id);
   const txns = ids.length
     ? await db
-        .select()
+        .select({
+          itemId: transactions.itemId,
+          shippingCost: transactions.shippingCost,
+          platformFees: transactions.platformFees,
+        })
         .from(transactions)
         .where(
           and(

--- a/src/lib/analytics/health.ts
+++ b/src/lib/analytics/health.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, gte, or } from "drizzle-orm";
+import { and, eq, isNotNull, gte, or, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items } from "@/db/schema";
 import { computeCadence, type CadenceResult } from "@/lib/inventory/cadence";
@@ -18,7 +18,22 @@ export async function computeHealth(userId: string) {
   // Pull the active inventory (listed + sourced) plus recent listed timestamps
   // for cadence. One round-trip via union of conditions keeps this cheap.
   const allRelevant = await db
-    .select()
+    .select({
+      id: items.id,
+      name: items.name,
+      brand: items.brand,
+      category: items.category,
+      size: items.size,
+      description: items.description,
+      vintedUrl: items.vintedUrl,
+      status: items.status,
+      costPrice: items.costPrice,
+      listedPrice: items.listedPrice,
+      listedAt: items.listedAt,
+      lastEditedAt: items.lastEditedAt,
+      createdAt: items.createdAt,
+      photoCount: sql<number>`COALESCE(array_length(${items.photoUrls}, 1), 0)`.as("photo_count"),
+    })
     .from(items)
     .where(
       and(
@@ -56,7 +71,7 @@ export async function computeHealth(userId: string) {
       category: r.category,
       size: r.size,
       description: r.description,
-      photoUrls: r.photoUrls ?? null,
+      photoCount: r.photoCount,
       vintedUrl: r.vintedUrl,
     })),
     5,
@@ -114,7 +129,7 @@ export async function computeHealth(userId: string) {
       category: r.category,
       size: r.size,
       description: r.description,
-      photoUrls: r.photoUrls ?? null,
+      photoCount: r.photoCount,
       vintedUrl: r.vintedUrl,
     });
     const gap = Math.max(0.2, (100 - score) / 100);

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, gte, ilike, lte, or, type SQL } from "drizzle-orm";
+import { and, asc, count, desc, eq, gte, ilike, lte, or, sql, type SQL } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
   priceData,
@@ -16,6 +16,28 @@ type NewExpense = typeof expenses.$inferInsert;
 type NewItem = typeof items.$inferInsert;
 type NewTransaction = typeof transactions.$inferInsert;
 type ItemUpdate = Partial<typeof items.$inferInsert>;
+
+/** Slim column set for dedup lookups — everything except the photo blobs.
+ *  Selecting `photo_urls` here would pull every item's base64 array (~150KB
+ *  each) just to check whether it's empty in the dedup branch below.
+ *  We expose `hasPhotos` as a boolean derived in SQL instead. */
+const FIND_ITEM_COLS = {
+  id: items.id,
+  userId: items.userId,
+  name: items.name,
+  brand: items.brand,
+  category: items.category,
+  condition: items.condition,
+  size: items.size,
+  costPrice: items.costPrice,
+  listedPrice: items.listedPrice,
+  soldPrice: items.soldPrice,
+  status: items.status,
+  description: items.description,
+  vintedUrl: items.vintedUrl,
+  thumbnailUrl: items.thumbnailUrl,
+  hasPhotos: sql<boolean>`COALESCE(array_length(${items.photoUrls}, 1), 0) > 0`.as("has_photos"),
+} as const;
 
 export type InventoryFilters = {
   status?: string | null;
@@ -123,7 +145,34 @@ export function userScope(userId: string) {
             : desc(items.createdAt);
 
       const rows = await db
-        .select()
+        .select({
+          id: items.id,
+          userId: items.userId,
+          name: items.name,
+          brand: items.brand,
+          category: items.category,
+          condition: items.condition,
+          size: items.size,
+          costPrice: items.costPrice,
+          listedPrice: items.listedPrice,
+          soldPrice: items.soldPrice,
+          status: items.status,
+          platform: items.platform,
+          thumbnailUrl: items.thumbnailUrl,
+          description: items.description,
+          sourceType: items.sourceType,
+          sourceLocation: items.sourceLocation,
+          vintedUrl: items.vintedUrl,
+          listedAt: items.listedAt,
+          soldAt: items.soldAt,
+          buyerPaidShipping: items.buyerPaidShipping,
+          shippedAt: items.shippedAt,
+          lastEditedAt: items.lastEditedAt,
+          relistCount: items.relistCount,
+          createdAt: items.createdAt,
+          updatedAt: items.updatedAt,
+          isSample: items.isSample,
+        })
         .from(items)
         .where(and(...conds))
         .orderBy(orderBy);
@@ -153,7 +202,7 @@ export function userScope(userId: string) {
 
     findItemByVintedUrl: async (url: string) => {
       const [row] = await db
-        .select()
+        .select(FIND_ITEM_COLS)
         .from(items)
         .where(and(eq(items.userId, userId), eq(items.vintedUrl, url)))
         .limit(1);
@@ -162,7 +211,7 @@ export function userScope(userId: string) {
 
     findItemByName: async (name: string) => {
       const [row] = await db
-        .select()
+        .select(FIND_ITEM_COLS)
         .from(items)
         .where(and(eq(items.userId, userId), ilike(items.name, name.trim())))
         .limit(1);

--- a/src/lib/inventory/completeness.ts
+++ b/src/lib/inventory/completeness.ts
@@ -35,7 +35,10 @@ export interface ItemLike {
   category: string | null;
   size: string | null;
   description: string | null;
-  photoUrls: string[] | null;
+  /** Either pass the array (legacy) or a precomputed count (preferred — avoids
+   *  pulling base64 blobs from Postgres just to call .length). */
+  photoUrls?: string[] | null;
+  photoCount?: number | null;
   vintedUrl: string | null;
 }
 
@@ -64,7 +67,12 @@ export function scoreItem(item: ItemLike): CompletenessResult {
     ["category", hasText(item.category)],
     ["size", hasText(item.size)],
     ["description", hasText(item.description, 40)],
-    ["photos", Array.isArray(item.photoUrls) && item.photoUrls.length >= 3],
+    [
+      "photos",
+      typeof item.photoCount === "number"
+        ? item.photoCount >= 3
+        : Array.isArray(item.photoUrls) && item.photoUrls.length >= 3,
+    ],
     ["title", wordCount(item.name) >= 4],
     ["vintedUrl", hasText(item.vintedUrl)],
   ];


### PR DESCRIPTION
## Summary

Two related changes that go together — the import surfaced the perf problem.

### 1. Backup importer
\`scripts/import-from-lily.mjs\` — one-off CLI to load a legacy single-tenant Relist JSON backup into this multi-tenant DB under a chosen Clerk userId, with every row tagged \`is_sample = true\` so it can be cleared via the existing UI banner.

- **Read-only** against the source backup file. Never touches the legacy app or DB.
- Drops \`vinted_url\` per request (no public links carried over).
- Bulk-inserts via \`sql.query()\` (the Neon serverless tagged-template doesn't support row arrays).

Already run once against Calvin's account: 120 items / 84 transactions / 3 expenses, 0 orphans.

### 2. Stop selecting base64 photo blobs in non-photo queries

The 120-item import pushed the \`items\` table to **46 MB** — almost all of it base64 thumbnails and photo arrays stored inline (planned migration to Vercel Blob is out of scope here). Every analytics query was doing \`db.select().from(items)\` and pulling all 46 MB across the wire from Neon on every render.

| Query | Before | After | Speedup |
|---|---|---|---|
| Health items | 19,938 ms | 105 ms | **190×** |
| Bestsellers items | 11,207 ms | 86 ms | **130×** |

Replaced bare \`select()\` with explicit column lists in:
- \`src/lib/analytics/health.ts\`
- \`src/lib/analytics/bestsellers.ts\`
- \`src/lib/db/scoped.ts\` (\`listItems\`, \`findItemByVintedUrl\`, \`findItemByName\`)

The completeness scorer used to read \`photoUrls.length\` purely to count — added an alternate \`photoCount\` field on \`ItemLike\` and derived it in SQL via \`array_length\`. Dedup helpers similarly get a boolean \`hasPhotos\` derived flag instead of the bytes.

Item-detail and the photo / backup API routes still pull full \`photoUrls\` intentionally — they actually render them.

## Test plan
- [ ] \`/dashboard\`, \`/health\`, \`/bestsellers\`, \`/profit\` all feel snappy (was 10–20s, should be sub-second)
- [ ] \`/inventory\` list still shows thumbnails (kept \`thumbnailUrl\` in the slim select)
- [ ] \`/inventory/[id]\` still shows full photo gallery
- [ ] \`/api/backup\` JSON export still includes photoUrls
- [ ] Item dedup on POST \`/api/inventory\` still updates photos when missing (uses new \`hasPhotos\` flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)