### PR TITLE
Inventory: default to listed, paginate (25/page)

### DIFF
--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -5,6 +5,7 @@ import { userScope } from "@/lib/db/scoped";
 import { FirstRunNudge } from "@/components/FirstRunNudge";
 
 const STATUSES = ["all", "sourced", "listed", "sold", "shipped"] as const;
+const PAGE_SIZE = 25;
 
 function gbp(n: string | null) {
   if (n == null) return "—";
@@ -14,34 +15,73 @@ function gbp(n: string | null) {
 export default async function InventoryPage({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string; search?: string; sort?: string; incomplete?: string }>;
+  searchParams: Promise<{
+    status?: string;
+    search?: string;
+    sort?: string;
+    incomplete?: string;
+    page?: string;
+  }>;
 }) {
   const { userId } = await auth();
   if (!userId) redirect("/");
 
   const sp = await searchParams;
-  const status = sp.status === "all" || !sp.status ? null : sp.status;
+
+  // Default filter: listed (active inventory). Empty string is treated the
+  // same as "listed" — only an explicit ?status=all bypasses to all.
+  const statusParam = sp.status ?? "listed";
+  const status = statusParam === "all" ? null : statusParam;
   const sort = sp.sort === "price" || sp.sort === "brand" ? sp.sort : "date";
+  const page = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
+
   const scope = userScope(userId);
-  const [rows, totalCount] = await Promise.all([
+  const [result, totalCount] = await Promise.all([
     scope.listItems({
       status,
       search: sp.search ?? null,
       sort,
       incompleteOnly: sp.incomplete === "1",
+      page,
+      pageSize: PAGE_SIZE,
     }),
     scope.countItems(),
   ]);
+
+  const { rows, total, pageCount } = result;
   const filtersApplied =
-    !!status || !!sp.search?.trim() || sp.incomplete === "1";
+    statusParam !== "listed" ||
+    !!sp.search?.trim() ||
+    sp.incomplete === "1";
   const isFirstRun = totalCount === 0;
+  const showStart = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const showEnd = Math.min(page * PAGE_SIZE, total);
+
+  // Build a query-string for prev/next that preserves filters
+  function pageHref(n: number): string {
+    const params = new URLSearchParams();
+    if (statusParam !== "listed") params.set("status", statusParam);
+    if (sp.search) params.set("search", sp.search);
+    if (sp.sort && sp.sort !== "date") params.set("sort", sp.sort);
+    if (sp.incomplete === "1") params.set("incomplete", "1");
+    if (n > 1) params.set("page", String(n));
+    const qs = params.toString();
+    return qs ? `/inventory?${qs}` : "/inventory";
+  }
 
   return (
     <div className="space-y-6">
       <header className="flex items-end justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Inventory</h1>
-          <p className="mt-1 text-sm text-gray-600">{rows.length} items</p>
+          <p className="mt-1 text-sm text-gray-600">
+            {total === 0
+              ? "0 items"
+              : `Showing ${showStart}–${showEnd} of ${total}`}
+            {totalCount > total && (
+              <span className="text-gray-400"> · {totalCount} total in account</span>
+            )}
+          </p>
         </div>
         <Link
           href="/inventory/new"
@@ -61,7 +101,7 @@ export default async function InventoryPage({
         />
         <select
           name="status"
-          defaultValue={sp.status ?? "all"}
+          defaultValue={statusParam}
           className="rounded-md border px-2 py-1.5"
         >
           {STATUSES.map((s) => (
@@ -102,65 +142,95 @@ export default async function InventoryPage({
           </p>
         )
       ) : (
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr className="border-b text-left text-xs uppercase text-gray-500">
-              <th className="w-12 py-2 pr-2"></th>
-              <th className="py-2 pr-4">Name</th>
-              <th className="py-2 pr-4">Brand</th>
-              <th className="py-2 pr-4">Size</th>
-              <th className="py-2 pr-4">Status</th>
-              <th className="py-2 pr-4 text-right">Cost</th>
-              <th className="py-2 pr-4 text-right">Listed</th>
-              <th className="py-2 pr-4 text-right">Sold</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r) => (
-              <tr key={r.id} className="border-b hover:bg-gray-50">
-                <td className="py-2 pr-2">
-                  <Link
-                    href={`/inventory/${r.id}`}
-                    aria-label={`View ${r.name}`}
-                    className="block"
-                  >
-                    {r.hasThumbnail ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={`/api/inventory/thumb/${r.id}`}
-                        alt=""
-                        loading="lazy"
-                        className="h-10 w-10 rounded object-cover bg-gray-100"
-                      />
-                    ) : (
-                      <div
-                        aria-hidden
-                        className="h-10 w-10 rounded bg-gray-100 flex items-center justify-center text-[10px] text-gray-400"
-                      >
-                        no img
-                      </div>
-                    )}
-                  </Link>
-                </td>
-                <td className="py-2 pr-4">
-                  <Link href={`/inventory/${r.id}`} className="underline">
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-2 pr-4">{r.brand ?? "—"}</td>
-                <td className="py-2 pr-4">{r.size ?? "—"}</td>
-                <td className="py-2 pr-4">
-                  <span className="rounded bg-gray-100 px-2 py-0.5 text-xs">
-                    {r.status}
-                  </span>
-                </td>
-                <td className="py-2 pr-4 text-right">{gbp(r.costPrice)}</td>
-                <td className="py-2 pr-4 text-right">{gbp(r.listedPrice)}</td>
-                <td className="py-2 pr-4 text-right">{gbp(r.soldPrice)}</td>
+        <>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase text-gray-500">
+                <th className="w-12 py-2 pr-2"></th>
+                <th className="py-2 pr-4">Name</th>
+                <th className="py-2 pr-4">Brand</th>
+                <th className="py-2 pr-4">Size</th>
+                <th className="py-2 pr-4">Status</th>
+                <th className="py-2 pr-4 text-right">Cost</th>
+                <th className="py-2 pr-4 text-right">Listed</th>
+                <th className="py-2 pr-4 text-right">Sold</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b hover:bg-gray-50">
+                  <td className="py-2 pr-2">
+                    <Link
+                      href={`/inventory/${r.id}`}
+                      aria-label={`View ${r.name}`}
+                      className="block"
+                    >
+                      {r.hasThumbnail ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={`/api/inventory/thumb/${r.id}`}
+                          alt=""
+                          loading="lazy"
+                          className="h-10 w-10 rounded object-cover bg-gray-100"
+                        />
+                      ) : (
+                        <div
+                          aria-hidden
+                          className="h-10 w-10 rounded bg-gray-100 flex items-center justify-center text-[10px] text-gray-400"
+                        >
+                          no img
+                        </div>
+                      )}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <Link href={`/inventory/${r.id}`} className="underline">
+                      {r.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-4">{r.brand ?? "—"}</td>
+                  <td className="py-2 pr-4">{r.size ?? "—"}</td>
+                  <td className="py-2 pr-4">
+                    <span className="rounded bg-gray-100 px-2 py-0.5 text-xs">
+                      {r.status}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-4 text-right">{gbp(r.costPrice)}</td>
+                  <td className="py-2 pr-4 text-right">{gbp(r.listedPrice)}</td>
+                  <td className="py-2 pr-4 text-right">{gbp(r.soldPrice)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {pageCount > 1 && (
+            <nav className="flex items-center justify-between gap-3 pt-2 text-sm">
+              {page > 1 ? (
+                <Link
+                  href={pageHref(page - 1)}
+                  className="rounded-md border px-3 py-1.5"
+                >
+                  ← Previous
+                </Link>
+              ) : (
+                <span className="text-gray-400">← Previous</span>
+              )}
+              <span className="text-gray-600">
+                Page {page} of {pageCount}
+              </span>
+              {page < pageCount ? (
+                <Link
+                  href={pageHref(page + 1)}
+                  className="rounded-md border px-3 py-1.5"
+                >
+                  Next →
+                </Link>
+              ) : (
+                <span className="text-gray-400">Next →</span>
+              )}
+            </nav>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -21,15 +21,25 @@ export async function GET(req: NextRequest) {
 
   const sp = req.nextUrl.searchParams;
   const sort = sp.get("sort");
-  const items = await userScope(u.userId).listItems({
+  const page = Math.max(1, parseInt(sp.get("page") ?? "1", 10) || 1);
+  const pageSize = Math.max(1, Math.min(200, parseInt(sp.get("pageSize") ?? "100", 10) || 100));
+  const result = await userScope(u.userId).listItems({
     status: sp.get("status"),
     search: sp.get("search"),
     sort: sort === "price" || sort === "brand" || sort === "date" ? sort : null,
     incompleteOnly: sp.get("incompleteOnly") === "1",
+    page,
+    pageSize,
   });
 
   return NextResponse.json(
-    { items },
+    {
+      items: result.rows,
+      page: result.page,
+      pageSize: result.pageSize,
+      total: result.total,
+      pageCount: result.pageCount,
+    },
     { headers: { "Cache-Control": "private, max-age=120, stale-while-revalidate=300" } },
   );
 }

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -44,6 +44,10 @@ export type InventoryFilters = {
   search?: string | null;
   sort?: "date" | "price" | "brand" | null;
   incompleteOnly?: boolean;
+  /** 1-based page number for pagination. Default: 1. */
+  page?: number;
+  /** Page size. Default: 25. Pass 0 to disable LIMIT (used by backups). */
+  pageSize?: number;
 };
 
 /**
@@ -125,7 +129,14 @@ export function userScope(userId: string) {
         .where(and(eq(expenses.userId, userId), eq(expenses.id, id)))
         .returning({ id: expenses.id }),
 
-    listItems: async ({ status, search, sort, incompleteOnly }: InventoryFilters = {}) => {
+    listItems: async ({
+      status,
+      search,
+      sort,
+      incompleteOnly,
+      page = 1,
+      pageSize = 25,
+    }: InventoryFilters = {}) => {
       const conds: SQL[] = [eq(items.userId, userId)];
       if (status) conds.push(eq(items.status, status));
       if (search) {
@@ -144,43 +155,77 @@ export function userScope(userId: string) {
             ? asc(items.brand)
             : desc(items.createdAt);
 
-      const rows = await db
-        .select({
-          id: items.id,
-          userId: items.userId,
-          name: items.name,
-          brand: items.brand,
-          category: items.category,
-          condition: items.condition,
-          size: items.size,
-          costPrice: items.costPrice,
-          listedPrice: items.listedPrice,
-          soldPrice: items.soldPrice,
-          status: items.status,
-          platform: items.platform,
-          hasThumbnail: sql<boolean>`${items.thumbnailUrl} IS NOT NULL`.as("has_thumbnail"),
-          description: items.description,
-          sourceType: items.sourceType,
-          sourceLocation: items.sourceLocation,
-          vintedUrl: items.vintedUrl,
-          listedAt: items.listedAt,
-          soldAt: items.soldAt,
-          buyerPaidShipping: items.buyerPaidShipping,
-          shippedAt: items.shippedAt,
-          lastEditedAt: items.lastEditedAt,
-          relistCount: items.relistCount,
-          createdAt: items.createdAt,
-          updatedAt: items.updatedAt,
-          isSample: items.isSample,
-        })
+      const cols = {
+        id: items.id,
+        userId: items.userId,
+        name: items.name,
+        brand: items.brand,
+        category: items.category,
+        condition: items.condition,
+        size: items.size,
+        costPrice: items.costPrice,
+        listedPrice: items.listedPrice,
+        soldPrice: items.soldPrice,
+        status: items.status,
+        platform: items.platform,
+        hasThumbnail: sql<boolean>`${items.thumbnailUrl} IS NOT NULL`.as("has_thumbnail"),
+        description: items.description,
+        sourceType: items.sourceType,
+        sourceLocation: items.sourceLocation,
+        vintedUrl: items.vintedUrl,
+        listedAt: items.listedAt,
+        soldAt: items.soldAt,
+        buyerPaidShipping: items.buyerPaidShipping,
+        shippedAt: items.shippedAt,
+        lastEditedAt: items.lastEditedAt,
+        relistCount: items.relistCount,
+        createdAt: items.createdAt,
+        updatedAt: items.updatedAt,
+        isSample: items.isSample,
+      };
+
+      // incompleteOnly is a post-filter (multi-column NULL/empty-string check)
+      // — when set we skip SQL pagination and let the page render the slice.
+      if (incompleteOnly) {
+        const all = await db
+          .select(cols)
+          .from(items)
+          .where(and(...conds))
+          .orderBy(orderBy);
+        const filtered = all.filter(
+          (r) => !r.brand || !r.category || !r.size || !r.condition || !r.listedPrice,
+        );
+        return {
+          rows: filtered,
+          total: filtered.length,
+          page: 1,
+          pageSize: filtered.length,
+          pageCount: 1,
+        };
+      }
+
+      const [{ n }] = await db
+        .select({ n: count() })
+        .from(items)
+        .where(and(...conds));
+      const total = Number(n ?? 0);
+
+      const safePage = Math.max(1, Math.floor(page));
+      const safeSize = pageSize > 0 ? Math.max(1, Math.floor(pageSize)) : total || 1;
+      const offset = (safePage - 1) * safeSize;
+      const pageCount = Math.max(1, Math.ceil(total / safeSize));
+
+      const query = db
+        .select(cols)
         .from(items)
         .where(and(...conds))
         .orderBy(orderBy);
 
-      if (!incompleteOnly) return rows;
-      return rows.filter(
-        (r) => !r.brand || !r.category || !r.size || !r.condition || !r.listedPrice,
-      );
+      const rows = pageSize > 0
+        ? await query.limit(safeSize).offset(offset)
+        : await query;
+
+      return { rows, total, page: safePage, pageSize: safeSize, pageCount };
     },
 
     countItems: async () => {


### PR DESCRIPTION
## Summary

Two obvious-in-hindsight fixes Calvin called out:

1. **Default filter** is now \`listed\` (active inventory) instead of \`all\`. Most of the time you want to see what's currently for sale, not the full archive. Dropdown still offers all / sourced / listed / sold / shipped — only an explicit \`?status=all\` shows everything.

2. **Server-side pagination**, 25 per page, via LIMIT/OFFSET. Header shows *Showing N–M of T* plus the all-account total when filtered. Prev / Next links preserve all filter state via querystring.

\`scoped.listItems\` now returns \`{ rows, total, page, pageSize, pageCount }\` instead of a bare array. The \`/api/inventory\` extension route takes new \`page\` / \`pageSize\` params (capped at 200 per page) and returns the same shape.

The \`incompleteOnly\` checkbox path skips pagination (can't paginate after a JS post-filter) and reports the full filtered count — acceptable since it's a lower-traffic mode.

## Test plan
- [ ] \`/inventory\` defaults to listed, shows ~25 items
- [ ] Header reads \`Showing 1–25 of 59 · 121 total in account\`
- [ ] Prev / Next paginate; current filter (status, sort, search) survives the link
- [ ] \`?status=all\` shows everything paged
- [ ] \`?incomplete=1\` still works (no pagination, all matches)
- [ ] Chrome extension calling \`/api/inventory\` still receives the items array (now nested under \`.items\`, plus pagination metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)