### PR TITLE
Item detail: design rebuild (#24)

### DIFF
--- a/src/app/(app)/inventory/[id]/actions.tsx
+++ b/src/app/(app)/inventory/[id]/actions.tsx
@@ -1,18 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
 
 type Status = "sourced" | "listed" | "sold" | "shipped";
+
+function gbpNum(n: string | null | undefined): number {
+  if (n == null || n === "") return 0;
+  const v = parseFloat(n);
+  return Number.isFinite(v) ? v : 0;
+}
 
 export function ItemActions({
   id,
   status,
+  costPrice,
   listedPrice,
   soldPrice,
 }: {
   id: string;
   status: string;
+  costPrice: string | null;
   listedPrice: string | null;
   soldPrice: string | null;
 }) {
@@ -24,6 +33,14 @@ export function ItemActions({
     shippingCost: "0",
     platformFees: "0",
   });
+
+  const estimatedProfit = useMemo(() => {
+    const gross = gbpNum(sell.soldPrice);
+    const ship = gbpNum(sell.shippingCost);
+    const fees = gbpNum(sell.platformFees);
+    const cost = gbpNum(costPrice);
+    return gross - ship - fees - cost;
+  }, [sell, costPrice]);
 
   async function transition(next: Status) {
     if (next === "sold") {
@@ -58,92 +75,176 @@ export function ItemActions({
     }
   }
 
-  async function remove() {
-    if (!confirm("Delete this item and its transactions?")) return;
-    const res = await fetch(`/api/inventory/${id}`, { method: "DELETE" });
-    if (res.ok) router.push("/inventory");
-  }
-
-  const next: Record<string, Status[]> = {
-    sourced: ["listed"],
-    listed: ["sold", "sourced"],
-    sold: ["shipped"],
-    shipped: [],
+  // primary / secondary buttons by status
+  const primaryByStatus: Partial<Record<Status, { label: string; next: Status }>> = {
+    sourced: { label: "Mark as listed", next: "listed" },
+    listed: { label: "Mark as sold", next: "sold" },
+    sold: { label: "Mark as shipped", next: "shipped" },
+  };
+  const secondaryByStatus: Partial<Record<Status, { label: string; next: Status }>> = {
+    listed: { label: "Mark as sourced", next: "sourced" },
   };
 
+  const primary = primaryByStatus[status as Status];
+  const secondary = secondaryByStatus[status as Status];
+
+  if (!primary && !secondary && !showSell) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {next[status]?.map((s) => (
-        <button
-          key={s}
-          disabled={busy}
-          onClick={() => transition(s)}
-          className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-50"
-        >
-          Mark as {s}
-        </button>
-      ))}
-      <button
-        onClick={remove}
-        disabled={busy}
-        className="ml-auto rounded-md border border-red-200 px-3 py-1.5 text-sm text-red-600 disabled:opacity-50"
-      >
-        Delete
-      </button>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {primary && (
+          <Button
+            disabled={busy}
+            onClick={() => transition(primary.next)}
+            variant="primary"
+            size="md"
+          >
+            {primary.label}
+          </Button>
+        )}
+        {secondary && (
+          <Button
+            disabled={busy}
+            onClick={() => transition(secondary.next)}
+            variant="secondary"
+            size="md"
+          >
+            {secondary.label}
+          </Button>
+        )}
+      </div>
 
       {showSell && (
         <form
           onSubmit={confirmSell}
-          className="mt-3 w-full rounded-md border bg-amber-50 p-4"
+          className="rounded-[var(--radius-lg)] border border-[var(--accent-amber)]/40 bg-[var(--accent-amber-soft)] p-5"
         >
-          <div className="text-sm font-medium">Mark as sold</div>
-          <div className="mt-3 grid grid-cols-3 gap-3 text-sm">
-            <label className="flex flex-col gap-1">
-              <span className="text-xs text-gray-600">Sold price (£)</span>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-[var(--accent-amber-soft-fg)]">
+                Mark as sold
+              </h3>
+              <p className="mt-0.5 text-xs text-[var(--accent-amber-soft-fg)]/80">
+                Record the sale to update profit and transactions.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <Field label="Sold price (£)">
               <input
                 type="number"
                 step="0.01"
                 value={sell.soldPrice}
-                onChange={(e) => setSell({ ...sell, soldPrice: e.target.value })}
-                className="rounded-md border px-2 py-1.5"
+                onChange={(e) =>
+                  setSell({ ...sell, soldPrice: e.target.value })
+                }
                 required
+                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
               />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs text-gray-600">Shipping (£)</span>
+            </Field>
+            <Field label="Shipping (£)">
               <input
                 type="number"
                 step="0.01"
                 value={sell.shippingCost}
-                onChange={(e) => setSell({ ...sell, shippingCost: e.target.value })}
-                className="rounded-md border px-2 py-1.5"
+                onChange={(e) =>
+                  setSell({ ...sell, shippingCost: e.target.value })
+                }
+                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
               />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-xs text-gray-600">Platform fees (£)</span>
+            </Field>
+            <Field label="Platform fees (£)">
               <input
                 type="number"
                 step="0.01"
                 value={sell.platformFees}
-                onChange={(e) => setSell({ ...sell, platformFees: e.target.value })}
-                className="rounded-md border px-2 py-1.5"
+                onChange={(e) =>
+                  setSell({ ...sell, platformFees: e.target.value })
+                }
+                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
               />
-            </label>
+            </Field>
           </div>
-          <div className="mt-3 flex gap-2">
-            <button className="rounded-md bg-black px-3 py-1.5 text-sm text-white">
+
+          <div className="mt-4 flex items-center justify-between rounded-[var(--radius-md)] bg-white/60 px-3 py-2 text-sm">
+            <span className="text-[var(--accent-amber-soft-fg)]">
+              Estimated profit
+            </span>
+            <span
+              className={`font-semibold ${
+                estimatedProfit >= 0
+                  ? "text-[var(--accent-emerald-soft-fg)]"
+                  : "text-[var(--accent-rose-soft-fg)]"
+              }`}
+            >
+              £{estimatedProfit.toFixed(2)}
+            </span>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button type="submit" variant="primary" size="md" disabled={busy}>
               Confirm sale
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
+              size="md"
               onClick={() => setShowSell(false)}
-              className="rounded-md border px-3 py-1.5 text-sm"
+              disabled={busy}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </form>
       )}
     </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-[var(--accent-amber-soft-fg)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+export function DeleteItemButton({ id }: { id: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function remove() {
+    if (!confirm("Delete this item and its transactions?")) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/inventory/${id}`, { method: "DELETE" });
+      if (res.ok) router.push("/inventory");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Button
+      variant="destructive"
+      size="md"
+      onClick={remove}
+      disabled={busy}
+    >
+      Delete item
+    </Button>
   );
 }

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -2,12 +2,43 @@ import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { userScope } from "@/lib/db/scoped";
-import { ItemActions } from "./actions";
+import { Card, StatusPill } from "@/components/ui";
+import { DeleteItemButton, ItemActions } from "./actions";
 import { ItemPhotos } from "./photos";
 
 function gbp(n: string | null) {
   return n == null ? "—" : `£${parseFloat(n).toFixed(2)}`;
 }
+
+function formatDateTime(d: Date | string | null) {
+  if (!d) return "—";
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatDate(d: Date | string | null) {
+  if (!d) return "—";
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+const CONDITION_LABEL: Record<string, string> = {
+  new: "New",
+  like_new: "Like new",
+  good: "Good",
+  fair: "Fair",
+  very_good: "Very good",
+};
 
 export default async function ItemDetail({
   params,
@@ -24,84 +55,168 @@ export default async function ItemDetail({
 
   const txns = await scope.listTransactionsForItem(id);
 
+  const subtitleParts = [item.brand, item.category, item.size].filter(Boolean);
+
   return (
-    <div className="max-w-3xl space-y-8">
-      <div className="flex items-start justify-between">
-        <div>
-          <Link href="/inventory" className="text-xs text-gray-500 underline">
-            ← Inventory
-          </Link>
-          <h1 className="mt-1 text-2xl font-semibold">{item.name}</h1>
-          <p className="text-sm text-gray-600">
-            {[item.brand, item.category, item.size].filter(Boolean).join(" · ") || "—"}
-          </p>
+    <div className="space-y-6">
+      {/* Header */}
+      <header className="space-y-2">
+        <Link
+          href="/inventory"
+          className="inline-flex items-center gap-1 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        >
+          <span aria-hidden>←</span> Inventory
+        </Link>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+              {item.name}
+            </h1>
+            {subtitleParts.length > 0 && (
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                {subtitleParts.join(" · ")}
+              </p>
+            )}
+          </div>
+          <StatusPill status={item.status} size="md" />
         </div>
-        <span className="rounded bg-gray-100 px-2 py-1 text-xs">{item.status}</span>
+      </header>
+
+      {/* Hero row: photos (left) + facts/actions (right) */}
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <Card>
+          <ItemPhotos itemId={item.id} initialPhotos={item.photoUrls ?? []} />
+        </Card>
+
+        <div className="space-y-4">
+          <Card>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <Row label="Cost" value={gbp(item.costPrice)} />
+              <Row label="Listed" value={gbp(item.listedPrice)} />
+              <Row label="Sold" value={gbp(item.soldPrice)} />
+              <Row
+                label="Condition"
+                value={
+                  item.condition
+                    ? CONDITION_LABEL[item.condition] ?? item.condition
+                    : "—"
+                }
+              />
+              <Row label="Listed at" value={formatDateTime(item.listedAt)} />
+              <Row label="Sold at" value={formatDateTime(item.soldAt)} />
+              {item.shippedAt && (
+                <Row
+                  label="Shipped at"
+                  value={formatDateTime(item.shippedAt)}
+                />
+              )}
+            </dl>
+          </Card>
+
+          <Card>
+            <ItemActions
+              id={item.id}
+              status={item.status}
+              costPrice={item.costPrice}
+              listedPrice={item.listedPrice}
+              soldPrice={item.soldPrice}
+            />
+          </Card>
+
+          <div className="flex justify-end">
+            <DeleteItemButton id={item.id} />
+          </div>
+        </div>
       </div>
 
-      <dl className="grid grid-cols-2 gap-4 text-sm md:grid-cols-3">
-        <Row label="Cost" value={gbp(item.costPrice)} />
-        <Row label="Listed" value={gbp(item.listedPrice)} />
-        <Row label="Sold" value={gbp(item.soldPrice)} />
-        <Row label="Condition" value={item.condition ?? "—"} />
-        <Row
-          label="Listed at"
-          value={item.listedAt ? new Date(item.listedAt).toLocaleDateString() : "—"}
-        />
-        <Row
-          label="Sold at"
-          value={item.soldAt ? new Date(item.soldAt).toLocaleDateString() : "—"}
-        />
-      </dl>
-
-      <ItemPhotos itemId={item.id} initialPhotos={item.photoUrls ?? []} />
-
+      {/* Description */}
       {item.description && (
-        <p className="whitespace-pre-wrap rounded-md border bg-gray-50 p-4 text-sm">
-          {item.description}
-        </p>
+        <Card>
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)]">
+            Description
+          </h2>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-[var(--text-primary)]">
+            {item.description}
+          </p>
+        </Card>
       )}
 
-      <ItemActions
-        id={item.id}
-        status={item.status}
-        listedPrice={item.listedPrice}
-        soldPrice={item.soldPrice}
-      />
-
-      <section>
-        <h2 className="text-sm font-medium text-gray-600">Transactions</h2>
+      {/* Transactions */}
+      <Card padded={false}>
+        <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-5 py-4">
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)]">
+            Transactions
+          </h2>
+          <span className="text-xs text-[var(--text-muted)]">
+            {txns.length} {txns.length === 1 ? "entry" : "entries"}
+          </span>
+        </div>
         {txns.length === 0 ? (
-          <p className="mt-2 text-sm text-gray-500">No transactions yet.</p>
+          <p className="px-5 py-6 text-sm text-[var(--text-muted)]">
+            No transactions yet.
+          </p>
         ) : (
-          <table className="mt-2 w-full border-collapse text-sm">
-            <thead>
-              <tr className="border-b text-left text-xs uppercase text-gray-500">
-                <th className="py-2 pr-4">Type</th>
-                <th className="py-2 pr-4">Gross</th>
-                <th className="py-2 pr-4">Shipping</th>
-                <th className="py-2 pr-4">Fees</th>
-                <th className="py-2 pr-4">Profit</th>
-                <th className="py-2 pr-4">Completed</th>
-              </tr>
-            </thead>
-            <tbody>
-              {txns.map((t) => (
-                <tr key={t.id} className="border-b">
-                  <td className="py-2 pr-4">{t.transactionType}</td>
-                  <td className="py-2 pr-4">{gbp(t.grossPrice)}</td>
-                  <td className="py-2 pr-4">{gbp(t.shippingCost)}</td>
-                  <td className="py-2 pr-4">{gbp(t.platformFees)}</td>
-                  <td className="py-2 pr-4">{gbp(t.profit)}</td>
-                  <td className="py-2 pr-4 text-xs text-gray-500">
-                    {t.completedAt ? new Date(t.completedAt).toLocaleString() : "—"}
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border-subtle)] bg-[var(--surface-muted)] text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                  <th className="px-5 py-2.5 font-medium">Type</th>
+                  <th className="px-3 py-2.5 font-medium">Gross</th>
+                  <th className="px-3 py-2.5 font-medium">Shipping</th>
+                  <th className="px-3 py-2.5 font-medium">Fees</th>
+                  <th className="px-3 py-2.5 font-medium">Profit</th>
+                  <th className="px-5 py-2.5 font-medium">Completed</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {txns.map((t, i) => {
+                  const profitNum =
+                    t.profit != null ? parseFloat(t.profit) : null;
+                  return (
+                    <tr
+                      key={t.id}
+                      className={
+                        i === txns.length - 1
+                          ? ""
+                          : "border-b border-[var(--border-subtle)]"
+                      }
+                    >
+                      <td className="px-5 py-3">
+                        <span className="inline-flex items-center rounded-[var(--radius-sm)] bg-[var(--surface-muted)] px-2 py-0.5 text-xs capitalize text-[var(--text-secondary)]">
+                          {t.transactionType.replace(/_/g, " ")}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 text-[var(--text-primary)]">
+                        {gbp(t.grossPrice)}
+                      </td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">
+                        {gbp(t.shippingCost)}
+                      </td>
+                      <td className="px-3 py-3 text-[var(--text-secondary)]">
+                        {gbp(t.platformFees)}
+                      </td>
+                      <td
+                        className={`px-3 py-3 font-medium ${
+                          profitNum == null
+                            ? "text-[var(--text-secondary)]"
+                            : profitNum >= 0
+                              ? "text-[var(--accent-emerald-soft-fg)]"
+                              : "text-[var(--accent-rose-soft-fg)]"
+                        }`}
+                      >
+                        {gbp(t.profit)}
+                      </td>
+                      <td className="px-5 py-3 text-xs text-[var(--text-muted)]">
+                        {formatDate(t.completedAt)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         )}
-      </section>
+      </Card>
     </div>
   );
 }
@@ -109,8 +224,12 @@ export default async function ItemDetail({
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-xs uppercase text-gray-500">{label}</dt>
-      <dd className="mt-0.5">{value}</dd>
+      <dt className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm font-medium text-[var(--text-primary)]">
+        {value}
+      </dd>
     </div>
   );
 }

--- a/src/app/(app)/inventory/[id]/photos.tsx
+++ b/src/app/(app)/inventory/[id]/photos.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
 
 const MAX_PHOTOS = 10;
 const MAX_BATCH = 5;
@@ -16,10 +17,12 @@ export function ItemPhotos({
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [photos, setPhotos] = useState<string[]>(initialPhotos);
+  const [activeIndex, setActiveIndex] = useState(0);
   const [busy, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
 
   const canAdd = photos.length < MAX_PHOTOS && !busy;
+  const active = photos[activeIndex] ?? photos[0];
 
   async function readFiles(files: FileList): Promise<string[]> {
     const slots = MAX_PHOTOS - photos.length;
@@ -75,60 +78,95 @@ export function ItemPhotos({
         return;
       }
       const body = await res.json();
-      setPhotos(body.item.photoUrls ?? []);
+      const nextPhotos: string[] = body.item.photoUrls ?? [];
+      setPhotos(nextPhotos);
+      setActiveIndex((i) => Math.min(i, Math.max(0, nextPhotos.length - 1)));
       router.refresh();
     });
   }
 
   return (
-    <section>
-      <div className="flex items-end justify-between">
-        <h2 className="text-sm font-medium text-gray-600">
-          Photos {photos.length > 0 && <span className="text-gray-400">· {photos.length}/{MAX_PHOTOS}</span>}
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-medium text-[var(--text-secondary)]">
+          Photos
+          {photos.length > 0 && (
+            <span className="ml-1 text-[var(--text-muted)]">
+              · {photos.length}/{MAX_PHOTOS}
+            </span>
+          )}
         </h2>
         {canAdd && (
-          <button
+          <Button
             type="button"
+            size="sm"
+            variant="secondary"
             onClick={() => inputRef.current?.click()}
-            className="rounded-md border px-3 py-1.5 text-sm hover:bg-gray-50 disabled:opacity-50"
             disabled={busy}
           >
             {busy ? "Uploading…" : "Add photos"}
-          </button>
+          </Button>
         )}
       </div>
 
       {error && (
-        <p className="mt-2 rounded-md bg-red-50 p-2 text-xs text-red-700">
+        <p className="rounded-[var(--radius-md)] bg-[var(--accent-rose-soft)] p-2 text-xs text-[var(--accent-rose-soft-fg)]">
           {error}
         </p>
       )}
 
       {photos.length === 0 ? (
-        <p className="mt-2 text-sm text-gray-500">
-          No photos yet. {canAdd && "Add up to 10 — they will be resized to 1200px."}
-        </p>
-      ) : (
-        <div className="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-5">
-          {photos.map((src, i) => (
-            <div
-              key={i}
-              className="relative aspect-square overflow-hidden rounded-md border bg-gray-50"
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={src} alt={`Photo ${i + 1}`} className="h-full w-full object-cover" />
-              <button
-                type="button"
-                onClick={() => handleRemove(i)}
-                disabled={busy}
-                aria-label={`Remove photo ${i + 1}`}
-                className="absolute right-1 top-1 rounded bg-white/90 px-1.5 py-0.5 text-xs text-red-700 shadow hover:bg-white disabled:opacity-50"
-              >
-                ✕
-              </button>
-            </div>
-          ))}
+        <div className="flex aspect-square w-full items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-[var(--border-subtle)] bg-[var(--surface-inset)] text-sm text-[var(--text-muted)]">
+          {canAdd
+            ? "No photos yet — add up to 10 (resized to 1200px)."
+            : "No photos."}
         </div>
+      ) : (
+        <>
+          <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={active}
+              alt={`Photo ${activeIndex + 1}`}
+              className="h-full w-full object-cover"
+            />
+            <button
+              type="button"
+              onClick={() => handleRemove(activeIndex)}
+              disabled={busy}
+              aria-label={`Remove photo ${activeIndex + 1}`}
+              className="absolute right-2 top-2 rounded-[var(--radius-sm)] bg-white/90 px-2 py-1 text-xs font-medium text-[var(--accent-rose-soft-fg)] shadow-[var(--elev-1)] hover:bg-white disabled:opacity-50"
+            >
+              Remove
+            </button>
+          </div>
+
+          {photos.length > 1 && (
+            <div className="grid grid-cols-5 gap-2">
+              {photos.map((src, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => setActiveIndex(i)}
+                  aria-label={`Show photo ${i + 1}`}
+                  aria-current={i === activeIndex}
+                  className={`relative aspect-square overflow-hidden rounded-[var(--radius-md)] border bg-[var(--surface-inset)] transition ${
+                    i === activeIndex
+                      ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
+                      : "border-[var(--border-subtle)] hover:border-[var(--border-default)]"
+                  }`}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={src}
+                    alt={`Thumbnail ${i + 1}`}
+                    className="h-full w-full object-cover"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </>
       )}
 
       <input


### PR DESCRIPTION
## Summary
Rebuilds `/inventory/[id]` to match `Layout/05-item-detail.png`. Pure UI work — data layer untouched.

- Header: breadcrumb, display title (Fraunces), subtitle, `StatusPill`
- Photo gallery as hero: large square preview + thumbnail strip with active-thumb ring, "Add photos" in card header, "Remove" overlay on the active photo
- Right-side facts `Card` (definition list): Cost / Listed / Sold / Condition / Listed at / Sold at (+ Shipped at when set)
- Status-driven primary action zone in its own `Card`:
  - `sourced` -> Mark as listed (primary)
  - `listed`  -> Mark as sold (primary, opens amber inline form) + Mark as sourced (secondary)
  - `sold`    -> Mark as shipped (primary)
  - `shipped` -> hidden
- Amber inline sale form (Sold price / Shipping / Fees) with live "Estimated profit" readout, Confirm sale + Cancel
- Delete button (destructive variant, red) right-aligned below the action card
- Description in its own `Card`
- Transactions table restyled: muted header row, type chip, emerald/rose profit colour

## Assumptions
- Estimated profit in the amber form = sold − shipping − fees − cost (no other expense rollups; matches existing transaction profit math at the field-name level).
- "Listed" and "Sold" rows in the facts panel show timestamps (date + HH:MM) per the mock; legacy code was date-only.
- Removed inventory thumbnail removal "✕" badge in favour of a single "Remove" overlay on the active hero photo (cleaner, matches the mock which doesn't show per-thumb removers).
- Reused existing design-system `Card`, `Button`, `StatusPill` — no new primitives, no new deps.

## Test plan
- [ ] Visit `/inventory/[id]` for items in each status (sourced / listed / sold / shipped) and confirm correct primary/secondary buttons appear
- [ ] Open the amber Mark-as-sold form, edit fields, confirm estimated profit updates live and Confirm sale persists
- [ ] Add a photo, remove the active photo, switch active thumbnail
- [ ] Delete an item from the detail page
- [ ] Confirm transactions table renders for items with sales recorded

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)