### PR TITLE
Settings: sub-nav + page restyle (#28)

### DIFF
--- a/src/app/(app)/settings/api-keys/client.tsx
+++ b/src/app/(app)/settings/api-keys/client.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Button, Card, CardHeader } from "@/components/ui";
 
 type Key = {
   id: string;
@@ -17,6 +18,7 @@ export function ApiKeysClient({ initialKeys }: { initialKeys: Key[] }) {
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
   const [justCreated, setJustCreated] = useState<{ name: string; token: string } | null>(null);
+  const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function create(e: React.FormEvent) {
@@ -32,12 +34,23 @@ export function ApiKeysClient({ initialKeys }: { initialKeys: Key[] }) {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Failed");
       setJustCreated({ name: data.name, token: data.token });
+      setCopied(false);
       setName("");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed");
     } finally {
       setCreating(false);
+    }
+  }
+
+  async function copyToken(token: string) {
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* noop */
     }
   }
 
@@ -54,84 +67,148 @@ export function ApiKeysClient({ initialKeys }: { initialKeys: Key[] }) {
   }
 
   return (
-    <div className="mt-6 space-y-8">
-      <form onSubmit={create} className="flex items-end gap-3">
-        <label className="flex flex-col text-sm">
-          <span className="mb-1 text-gray-600">Name</span>
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. My laptop"
-            className="rounded-md border px-3 py-2"
-            required
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={creating || !name}
-          className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
-        >
-          {creating ? "Creating…" : "Create key"}
-        </button>
-        {error && <span className="text-sm text-red-600">{error}</span>}
-      </form>
+    <div className="space-y-6">
+      <section className="flex items-start gap-3 rounded-[var(--radius-md)] border border-[var(--accent-amber)]/40 bg-[var(--accent-amber-soft)] px-4 py-3 text-sm text-[var(--accent-amber-soft-fg)]">
+        <span aria-hidden className="mt-0.5 text-base leading-none">!</span>
+        <p>
+          Treat your API tokens like passwords. Don&apos;t share them in public
+          places — right now, you won&apos;t be able to read a key once it
+          leaves this page.
+        </p>
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Create a new API key"
+          description="Name it after the device or browser profile that will use it."
+        />
+        <form onSubmit={create} className="mt-4 flex flex-wrap items-end gap-3">
+          <label className="flex flex-1 min-w-[14rem] flex-col text-sm">
+            <span className="mb-1 text-[var(--text-secondary)]">Name</span>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. My laptop, or Work laptop"
+              className="rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-inset)] px-3 py-2 text-sm"
+              required
+            />
+          </label>
+          <Button type="submit" disabled={creating || !name}>
+            {creating ? "Creating…" : "+ Create key"}
+          </Button>
+          {error && (
+            <span className="text-sm text-[var(--accent-rose)]">{error}</span>
+          )}
+        </form>
+      </Card>
 
       {justCreated && (
-        <div className="rounded-md border border-amber-400 bg-amber-50 p-4 text-amber-950">
-          <p className="text-sm font-medium">
-            Copy this token now — you won&apos;t see it again.
-          </p>
-          <pre className="mt-2 overflow-x-auto rounded border border-amber-200 bg-white px-3 py-2 text-xs text-gray-900">
-            {justCreated.token}
-          </pre>
-          <button
-            onClick={() => {
-              navigator.clipboard.writeText(justCreated.token);
-            }}
-            className="mt-2 rounded-md border border-amber-300 bg-white px-3 py-1 text-sm text-amber-900 hover:bg-amber-100"
-          >
-            Copy
-          </button>
-        </div>
+        <section
+          role="alert"
+          className="rounded-[var(--radius-lg)] border-2 border-[var(--accent-amber)] bg-[var(--accent-amber-soft)] p-5 shadow-[var(--elev-2)]"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="font-display text-lg font-semibold text-[var(--accent-amber-soft-fg)]">
+                Copy this token now — you won&apos;t see it again.
+              </h2>
+              <p className="mt-1 text-sm text-[var(--accent-amber-soft-fg)]">
+                Paste it into the Relist Chrome extension under{" "}
+                <em>{justCreated.name}</em>. This token will not be shown again
+                after you close this message.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2 rounded-[var(--radius-md)] border border-[var(--accent-amber)]/50 bg-[var(--surface-card)] px-3 py-2">
+            <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-[var(--text-primary)]">
+              {justCreated.token}
+            </code>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => copyToken(justCreated.token)}
+            >
+              {copied ? "Copied!" : "Copy"}
+            </Button>
+          </div>
+          <div className="mt-3 flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setJustCreated(null)}
+            >
+              I&apos;ve saved it — close
+            </Button>
+          </div>
+        </section>
       )}
 
-      <div>
-        <h2 className="text-sm font-medium text-gray-600">Existing keys</h2>
-        {initialKeys.length === 0 ? (
-          <p className="mt-2 text-sm text-gray-500">No keys yet.</p>
-        ) : (
-          <ul className="mt-2 divide-y rounded-md border">
+      <Card>
+        <CardHeader
+          title="Your API keys"
+          description={
+            initialKeys.length === 0
+              ? "No keys yet. Create one above to get started."
+              : `${initialKeys.length} ${
+                  initialKeys.length === 1 ? "key" : "keys"
+                } total.`
+          }
+        />
+        {initialKeys.length > 0 && (
+          <ul className="mt-4 divide-y divide-[var(--border-subtle)] rounded-[var(--radius-md)] border border-[var(--border-subtle)]">
             {initialKeys.map((k) => (
-              <li key={k.id} className="flex items-center justify-between px-4 py-3 text-sm">
-                <div>
-                  <div className="font-medium">{k.name}</div>
-                  <div className="text-xs text-gray-500">
-                    {k.tokenPrefix}…{" · "}
+              <li
+                key={k.id}
+                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 text-sm"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-[var(--text-primary)]">
+                    {k.name}
+                  </div>
+                  <div className="mt-0.5 truncate text-xs text-[var(--text-secondary)]">
+                    <span className="font-mono">{k.tokenPrefix}…</span>
+                    {" · "}
                     created {new Date(k.createdAt).toLocaleDateString()}
-                    {k.lastUsedAt && ` · last used ${new Date(k.lastUsedAt).toLocaleDateString()}`}
-                    {k.revokedAt && ` · revoked`}
+                    {k.lastUsedAt &&
+                      ` · last used ${new Date(k.lastUsedAt).toLocaleDateString()}`}
                   </div>
                 </div>
-                {k.revokedAt ? (
-                  <button
-                    onClick={() => purge(k.id)}
-                    className="rounded-md border border-red-200 px-3 py-1 text-xs text-red-600 hover:bg-red-50"
-                  >
-                    Delete
-                  </button>
-                ) : (
-                  <button
-                    onClick={() => revoke(k.id)}
-                    className="rounded-md border px-3 py-1 text-xs"
-                  >
-                    Revoke
-                  </button>
-                )}
+                <div className="flex items-center gap-2">
+                  {k.revokedAt ? (
+                    <>
+                      <span className="rounded-full bg-[var(--surface-muted)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
+                        Revoked
+                      </span>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => purge(k.id)}
+                      >
+                        Delete
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <span className="rounded-full bg-[var(--brand-soft)] px-2 py-0.5 text-xs text-[var(--brand-soft-fg)]">
+                        Active
+                      </span>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => revoke(k.id)}
+                      >
+                        Revoke
+                      </Button>
+                    </>
+                  )}
+                </div>
               </li>
             ))}
           </ul>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/app/(app)/settings/api-keys/page.tsx
+++ b/src/app/(app)/settings/api-keys/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { userScope } from "@/lib/db/scoped";
+import { PageHeader } from "@/components/ui";
 import { ApiKeysClient } from "./client";
 
 export default async function ApiKeysPage() {
@@ -9,20 +10,21 @@ export default async function ApiKeysPage() {
 
   const keys = await userScope(userId).listApiKeys();
   return (
-    <div>
-      <h1 className="text-2xl font-semibold">API keys</h1>
-      <p className="mt-2 text-sm text-gray-600">
-        Used by the Relist Chrome extension to send Vinted listing data to your account.
-        Treat them like passwords. The full token is shown only once at creation.
-      </p>
-      <ApiKeysClient initialKeys={keys.map((k) => ({
-        id: k.id,
-        name: k.name,
-        tokenPrefix: k.tokenPrefix,
-        createdAt: k.createdAt.toISOString(),
-        lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
-        revokedAt: k.revokedAt?.toISOString() ?? null,
-      }))} />
+    <div className="space-y-6">
+      <PageHeader
+        title="API keys"
+        subtitle="Bearer tokens used by the Relist Chrome extension to send Vinted listing data into your account. Treat them like passwords — the full token is shown only once at creation."
+      />
+      <ApiKeysClient
+        initialKeys={keys.map((k) => ({
+          id: k.id,
+          name: k.name,
+          tokenPrefix: k.tokenPrefix,
+          createdAt: k.createdAt.toISOString(),
+          lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+          revokedAt: k.revokedAt?.toISOString() ?? null,
+        }))}
+      />
     </div>
   );
 }

--- a/src/app/(app)/settings/backup/page.tsx
+++ b/src/app/(app)/settings/backup/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, expenses, priceData, priceStats } from "@/db/schema";
+import { ButtonLink, Card, CardHeader, PageHeader } from "@/components/ui";
 import { RestoreForm } from "./restore-form";
 
 export default async function BackupSettings() {
@@ -19,52 +20,44 @@ export default async function BackupSettings() {
   const total = it + tx + ex + pd + ps;
 
   return (
-    <div className="max-w-2xl space-y-8">
-      <header>
-        <h1 className="text-2xl font-semibold">Backup &amp; restore</h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Download all your Relist data as a single JSON file, or restore
-          from a previous export. Only your rows are touched — never another
-          user&apos;s.
-        </p>
-      </header>
+    <div className="max-w-3xl space-y-6">
+      <PageHeader
+        title="Backup & restore"
+        subtitle="Download all your Relist data as a single JSON file, or restore from a previous export. Only your rows are touched — never another user's."
+      />
 
-      <section className="rounded-md border p-4">
-        <h2 className="text-sm font-medium">Current row counts</h2>
-        <dl className="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-5">
+      <Card>
+        <CardHeader title="Current row counts" />
+        <dl className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-5">
           <Stat label="Items" value={it} />
           <Stat label="Transactions" value={tx} />
           <Stat label="Expenses" value={ex} />
           <Stat label="Price data" value={pd} />
           <Stat label="Price stats" value={ps} />
         </dl>
-      </section>
+      </Card>
 
-      <section className="rounded-md border p-4">
-        <h2 className="text-sm font-medium">Download backup</h2>
-        <p className="mt-1 text-xs text-gray-600">
-          Includes items, transactions, expenses, price data and price stats.
-          API keys are excluded — tokens are hashed, regenerate them from
-          the API keys page.
-        </p>
-        <a
-          href="/api/backup"
-          className="mt-3 inline-block rounded-md bg-black px-3 py-1.5 text-sm text-white"
-        >
-          Download {total} rows
-        </a>
-      </section>
+      <Card>
+        <CardHeader
+          title="Download backup"
+          description="Includes items, transactions, expenses, price data and price stats. API keys are excluded — tokens are hashed, regenerate them from the API keys page."
+          action={
+            <ButtonLink href="/api/backup" external size="sm">
+              Download {total} rows
+            </ButtonLink>
+          }
+        />
+      </Card>
 
-      <section className="rounded-md border border-red-200 bg-red-50/50 p-4">
-        <h2 className="text-sm font-medium text-red-900">Restore from backup</h2>
-        <p className="mt-1 text-xs text-red-800">
-          This will <strong>delete every row you currently have</strong> and
-          replace it with the contents of the uploaded file. Your other Relist
-          accounts (and other users) are not touched. Recommended: download a
-          fresh backup first.
-        </p>
-        <RestoreForm />
-      </section>
+      <Card className="border-[var(--accent-rose)]/40 bg-[var(--accent-rose-soft)]">
+        <CardHeader
+          title="Restore from backup"
+          description="This will delete every row you currently have and replace it with the contents of the uploaded file. Your other Relist accounts (and other users) are not touched. Recommended: download a fresh backup first."
+        />
+        <div className="mt-4">
+          <RestoreForm />
+        </div>
+      </Card>
     </div>
   );
 }
@@ -72,8 +65,12 @@ export default async function BackupSettings() {
 function Stat({ label, value }: { label: string; value: number }) {
   return (
     <div>
-      <dt className="text-xs uppercase text-gray-500">{label}</dt>
-      <dd className="mt-0.5 text-lg font-semibold tabular-nums">{value}</dd>
+      <dt className="text-xs uppercase tracking-wide text-[var(--text-secondary)]">
+        {label}
+      </dt>
+      <dd className="mt-1 font-display text-2xl font-semibold tabular-nums text-[var(--text-primary)]">
+        {value}
+      </dd>
     </div>
   );
 }

--- a/src/app/(app)/settings/backup/restore-form.tsx
+++ b/src/app/(app)/settings/backup/restore-form.tsx
@@ -2,11 +2,13 @@
 
 import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
 
 export function RestoreForm() {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [confirm, setConfirm] = useState("");
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<{
     counts: Record<string, number>;
@@ -16,14 +18,28 @@ export function RestoreForm() {
 
   const armed = confirm.trim().toUpperCase() === "REPLACE";
 
-  async function handleFile(file: File) {
+  function pickFile() {
+    inputRef.current?.click();
+  }
+
+  function onFilePicked(file: File) {
     setError(null);
     setResult(null);
+    setPendingFile(file);
+  }
+
+  function cancelRestore() {
+    setPendingFile(null);
+  }
+
+  async function executeRestore() {
+    if (!pendingFile) return;
     let parsed: unknown;
     try {
-      parsed = JSON.parse(await file.text());
+      parsed = JSON.parse(await pendingFile.text());
     } catch {
       setError("That file isn't valid JSON.");
+      setPendingFile(null);
       return;
     }
 
@@ -34,6 +50,7 @@ export function RestoreForm() {
         body: JSON.stringify(parsed),
       });
       const body = await res.json().catch(() => ({}));
+      setPendingFile(null);
       if (!res.ok) {
         setError(body.error ?? `Restore failed (${res.status})`);
         return;
@@ -45,27 +62,31 @@ export function RestoreForm() {
   }
 
   return (
-    <div className="mt-3 space-y-3">
-      <label className="block text-xs font-medium text-red-900">
-        Type <code className="rounded bg-red-100 px-1">REPLACE</code> to enable
-        the restore button:
+    <div className="space-y-4">
+      <label className="block text-xs font-medium text-[var(--accent-rose-soft-fg)]">
+        Type{" "}
+        <code className="rounded bg-[var(--surface-card)] px-1 py-0.5 font-mono text-[var(--accent-rose)]">
+          REPLACE
+        </code>{" "}
+        to enable the restore button:
         <input
           type="text"
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}
-          className="mt-1 block w-48 rounded-md border border-red-300 px-2 py-1 text-sm font-mono"
+          className="mt-1 block w-48 rounded-[var(--radius-md)] border border-[var(--accent-rose)]/40 bg-[var(--surface-card)] px-2 py-1 font-mono text-sm"
         />
       </label>
 
       <div className="flex items-center gap-3">
-        <button
+        <Button
           type="button"
+          variant="destructive"
+          size="sm"
           disabled={!armed || busy}
-          onClick={() => inputRef.current?.click()}
-          className="rounded-md bg-red-600 px-3 py-1.5 text-sm text-white disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={pickFile}
         >
           {busy ? "Restoring…" : "Choose backup file…"}
-        </button>
+        </Button>
         <input
           ref={inputRef}
           type="file"
@@ -73,17 +94,19 @@ export function RestoreForm() {
           className="hidden"
           onChange={(e) => {
             const f = e.target.files?.[0];
-            if (f) handleFile(f);
+            if (f) onFilePicked(f);
             e.target.value = "";
           }}
         />
       </div>
 
       {error && (
-        <p className="rounded-md bg-red-100 p-2 text-xs text-red-800">{error}</p>
+        <p className="rounded-[var(--radius-md)] bg-[var(--accent-rose-soft)] px-3 py-2 text-xs text-[var(--accent-rose-soft-fg)]">
+          {error}
+        </p>
       )}
       {result && (
-        <div className="rounded-md bg-emerald-50 p-3 text-xs text-emerald-900">
+        <div className="rounded-[var(--radius-md)] bg-[var(--accent-emerald-soft)] p-3 text-xs text-[var(--accent-emerald-soft-fg)]">
           <p className="font-medium">Restored at {result.restoredAt}</p>
           <ul className="mt-1 space-y-0.5">
             {Object.entries(result.counts).map(([k, v]) => (
@@ -94,6 +117,80 @@ export function RestoreForm() {
           </ul>
         </div>
       )}
+
+      {pendingFile && (
+        <ConfirmRestoreModal
+          fileName={pendingFile.name}
+          fileSize={pendingFile.size}
+          busy={busy}
+          onCancel={cancelRestore}
+          onConfirm={executeRestore}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConfirmRestoreModal({
+  fileName,
+  fileSize,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  fileName: string;
+  fileSize: number;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const sizeKb = Math.max(1, Math.round(fileSize / 1024));
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="restore-confirm-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={busy ? undefined : onCancel}
+    >
+      <div
+        className="w-full max-w-md rounded-[var(--radius-lg)] border border-[var(--accent-rose)]/40 bg-[var(--surface-card)] p-5 shadow-[var(--elev-3)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2
+          id="restore-confirm-title"
+          className="font-display text-xl font-semibold text-[var(--accent-rose)]"
+        >
+          Replace all your data?
+        </h2>
+        <p className="mt-2 text-sm text-[var(--text-primary)]">
+          You&apos;re about to wipe every row you currently have and replace
+          it with the contents of <strong>{fileName}</strong> ({sizeKb} KB).
+        </p>
+        <p className="mt-2 text-sm text-[var(--text-secondary)]">
+          This cannot be undone. Other users&apos; data is not touched.
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? "Restoring…" : "Yes, replace my data"}
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,0 +1,20 @@
+import { SubNav } from "@/components/nav/SubNav";
+
+const ITEMS = [
+  { href: "/settings/api-keys", label: "API keys" },
+  { href: "/settings/backup", label: "Backup" },
+  { href: "/settings/targets", label: "Targets" },
+];
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-6">
+      <SubNav items={ITEMS} />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(app)/settings/targets/page.tsx
+++ b/src/app/(app)/settings/targets/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getTargets, TARGET_DEFAULTS } from "@/lib/settings";
+import { Button, Card, CardHeader, PageHeader } from "@/components/ui";
 import { saveTargetsAction } from "./actions";
 
 export default async function TargetsSettingsPage() {
@@ -10,45 +11,42 @@ export default async function TargetsSettingsPage() {
   const targets = await getTargets(userId);
 
   return (
-    <div className="max-w-2xl space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold">Targets</h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Tune the thresholds that drive your daily plan and health report.
-          Defaults work for most sellers — adjust if your cadence or stock
-          turnover is different.
-        </p>
-      </header>
+    <div className="max-w-3xl space-y-6">
+      <PageHeader
+        title="Targets"
+        subtitle="Tune the thresholds that drive your daily plan and health report. Defaults work for most sellers — adjust if your cadence or stock turnover is different."
+      />
 
-      <form action={saveTargetsAction} className="space-y-5 rounded-md border p-4">
-        <Field
-          name="staleListingDays"
-          label="Stale listing (days)"
-          help={`Listings older than this show up in the daily reprice lane. Default ${TARGET_DEFAULTS.staleListingDays}.`}
-          defaultValue={targets.staleListingDays}
+      <Card>
+        <CardHeader
+          title="Thresholds"
+          description="Saved values apply immediately to your plan and health views."
         />
-        <Field
-          name="refreshSuggestedDays"
-          label="Refresh suggested (days)"
-          help={`How long a listing can sit before health flags it as dead stock. Default ${TARGET_DEFAULTS.refreshSuggestedDays}.`}
-          defaultValue={targets.refreshSuggestedDays}
-        />
-        <Field
-          name="weeklyListingsTarget"
-          label="Weekly listings target"
-          help={`The cadence pace your health report compares against. Default ${TARGET_DEFAULTS.weeklyListingsTarget}.`}
-          defaultValue={targets.weeklyListingsTarget}
-        />
+        <form action={saveTargetsAction} className="mt-4 space-y-5">
+          <Field
+            name="staleListingDays"
+            label="Stale listing (days)"
+            help={`Listings older than this show up in the daily reprice lane. Default ${TARGET_DEFAULTS.staleListingDays}.`}
+            defaultValue={targets.staleListingDays}
+          />
+          <Field
+            name="refreshSuggestedDays"
+            label="Refresh suggested (days)"
+            help={`How long a listing can sit before health flags it as dead stock. Default ${TARGET_DEFAULTS.refreshSuggestedDays}.`}
+            defaultValue={targets.refreshSuggestedDays}
+          />
+          <Field
+            name="weeklyListingsTarget"
+            label="Weekly listings target"
+            help={`The cadence pace your health report compares against. Default ${TARGET_DEFAULTS.weeklyListingsTarget}.`}
+            defaultValue={targets.weeklyListingsTarget}
+          />
 
-        <div className="flex items-center gap-3 pt-2">
-          <button
-            type="submit"
-            className="rounded-md bg-black px-4 py-2 text-sm text-white"
-          >
-            Save targets
-          </button>
-        </div>
-      </form>
+          <div className="flex items-center gap-3 pt-2">
+            <Button type="submit">Save targets</Button>
+          </div>
+        </form>
+      </Card>
     </div>
   );
 }
@@ -66,17 +64,21 @@ function Field({
 }) {
   return (
     <label className="block">
-      <span className="text-sm font-medium">{label}</span>
+      <span className="text-sm font-medium text-[var(--text-primary)]">
+        {label}
+      </span>
       <input
         type="number"
         name={name}
         min={1}
         step={1}
         defaultValue={defaultValue}
-        className="mt-1 block w-32 rounded-md border px-3 py-2 text-sm"
+        className="mt-1 block w-32 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-inset)] px-3 py-2 text-sm tabular-nums"
         required
       />
-      <span className="mt-1 block text-xs text-gray-500">{help}</span>
+      <span className="mt-1 block text-xs text-[var(--text-secondary)]">
+        {help}
+      </span>
     </label>
   );
 }

--- a/src/components/nav/SubNav.tsx
+++ b/src/components/nav/SubNav.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type Item = { href: string; label: string };
+
+export function SubNav({ items }: { items: Item[] }) {
+  const pathname = usePathname();
+  return (
+    <nav
+      aria-label="Section navigation"
+      className="flex gap-1 border-b border-[var(--border-subtle)]"
+    >
+      {items.map((item) => {
+        const active =
+          pathname === item.href || pathname.startsWith(`${item.href}/`);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? "page" : undefined}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+              active
+                ? "border-[var(--brand)] text-[var(--text-primary)]"
+                : "border-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a Settings sub-nav (`API keys · Backup · Targets`) via a new shared `<SubNav>` component and a `(app)/settings/layout.tsx`, with active-route highlighting that matches mock 08.
- Lifts all three settings pages onto the design-system primitives (`Card`, `CardHeader`, `Button`, `ButtonLink`, `PageHeader`) and theme tokens.
- API keys: the "just created" amber reveal is now an impossible-to-miss bordered/elevated card with Copy + dismiss controls; existing keys list shows Active / Revoked status pills.
- Backup: row counts, download, and a visually quarantined rose-bordered restore card; restore now requires a modal confirm step (after the REPLACE typed confirmation) before executing.
- Targets: PageHeader + Card with primitive Button and themed numeric inputs (no behavior change).

No auth or API-key generation logic touched — visual + UX only. Build and typecheck pass.

Closes #28

## Test plan
- [ ] `/settings/api-keys` shows sub-nav with API keys highlighted; create a key and verify the amber reveal card is unmissable and Copy works.
- [ ] `/settings/backup` shows the rose-bordered restore card; selecting a backup file opens the modal; Cancel aborts; Confirm runs the restore.
- [ ] `/settings/targets` saves correctly via the existing server action.
- [ ] Sub-nav active state updates correctly when navigating between the three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)