### PR TITLE
Profit: design rebuild with charts (#25)

### DIFF
--- a/src/app/(app)/profit/charts.tsx
+++ b/src/app/(app)/profit/charts.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ProfitSeriesPoint } from "@/lib/analytics/profit-series";
+
+const gbp = (n: number) =>
+  `£${n.toLocaleString("en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const fmtDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+};
+
+export function RevenueVsCostsChart({ data }: { data: ProfitSeriesPoint[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-[var(--text-muted)]">
+        No data in this period.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-72 w-full">
+      <ResponsiveContainer>
+        <AreaChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="profit-rev" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--brand)" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="var(--brand)" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="profit-cost" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent-rose)" stopOpacity={0.3} />
+              <stop offset="100%" stopColor="var(--accent-rose)" stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="profit-net" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent-emerald)" stopOpacity={0.35} />
+              <stop offset="100%" stopColor="var(--accent-emerald)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke="var(--border-subtle)" strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={fmtDate}
+            stroke="var(--text-muted)"
+            tick={{ fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            minTickGap={32}
+          />
+          <YAxis
+            stroke="var(--text-muted)"
+            tick={{ fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) => `£${v}`}
+            width={48}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "var(--surface-card)",
+              border: "1px solid var(--border-subtle)",
+              borderRadius: "var(--radius-md)",
+              fontSize: 12,
+            }}
+            labelFormatter={(label) => fmtDate(label as string)}
+            formatter={(value, name) => [gbp(Number(value)), name as string]}
+          />
+          <Area
+            type="monotone"
+            dataKey="revenue"
+            name="Revenue"
+            stroke="var(--brand)"
+            strokeWidth={2}
+            fill="url(#profit-rev)"
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="cost"
+            name="Cost"
+            stroke="var(--accent-rose)"
+            strokeWidth={2}
+            fill="url(#profit-cost)"
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="netProfit"
+            name="Net profit"
+            stroke="var(--accent-emerald)"
+            strokeWidth={2}
+            fill="url(#profit-net)"
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export type CostSlice = { name: string; value: number; color: string };
+
+export function CostCompositionChart({
+  data,
+  centerLabel,
+  centerValue,
+}: {
+  data: CostSlice[];
+  centerLabel: string;
+  centerValue: string;
+}) {
+  const total = data.reduce((a, b) => a + b.value, 0);
+  if (total === 0) {
+    return (
+      <div className="flex h-56 items-center justify-center text-sm text-[var(--text-muted)]">
+        No costs in this period.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-56 w-full">
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="name"
+            innerRadius="62%"
+            outerRadius="92%"
+            paddingAngle={2}
+            stroke="var(--surface-card)"
+            strokeWidth={2}
+            isAnimationActive={false}
+          >
+            {data.map((entry) => (
+              <Cell key={entry.name} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={{
+              background: "var(--surface-card)",
+              border: "1px solid var(--border-subtle)",
+              borderRadius: "var(--radius-md)",
+              fontSize: 12,
+            }}
+            formatter={(value, name) => [gbp(Number(value)), name as string]}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+        <div className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+          {centerLabel}
+        </div>
+        <div className="font-display text-xl font-semibold tabular-nums text-[var(--text-primary)]">
+          {centerValue}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -1,10 +1,20 @@
 import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { computeProfit } from "@/lib/analytics/profit";
+import { computeProfitSeries } from "@/lib/analytics/profit-series";
 import { resolveDateRange } from "@/lib/date-range";
 import { userScope } from "@/lib/db/scoped";
 import { FirstRunNudge } from "@/components/FirstRunNudge";
+import {
+  Card,
+  CardHeader,
+  PageHeader,
+  Tile,
+} from "@/components/ui";
+import { CostCompositionChart, RevenueVsCostsChart } from "./charts";
+import type { CostSlice } from "./charts";
 
 const PRESETS = [
   { value: "this_month", label: "This month" },
@@ -12,10 +22,22 @@ const PRESETS = [
   { value: "last_90_days", label: "Last 90 days" },
   { value: "this_year", label: "This year" },
   { value: "tax_year", label: "Tax year (UK)" },
-  { value: "", label: "All time" },
+  { value: "all", label: "All time" },
 ];
 
-const gbp = (n: number) => `£${n.toFixed(2)}`;
+const gbp = (n: number) =>
+  `£${n.toLocaleString("en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const num0 = (n: number) => n.toLocaleString("en-GB");
+
+function formatRangeSubtitle(from: Date | null, to: Date | null) {
+  const fmt = (d: Date) =>
+    d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+  if (!from && !to) return "All time";
+  if (from && to) return `${fmt(from)} – ${fmt(to)}`;
+  if (from) return `From ${fmt(from)}`;
+  if (to) return `Up to ${fmt(to)}`;
+  return "";
+}
 
 export default async function ProfitPage({
   searchParams,
@@ -26,32 +48,57 @@ export default async function ProfitPage({
   if (!userId) redirect("/");
 
   const { preset = "this_month" } = await searchParams;
-  const range = resolveDateRange(preset || null, null, null);
-  const [r, itemCount] = await Promise.all([
+  const presetKey = preset === "all" ? "" : preset;
+  const range = resolveDateRange(presetKey || null, null, null);
+
+  const [r, series, itemCount] = await Promise.all([
     computeProfit(userId, range),
+    computeProfitSeries(userId, range),
     userScope(userId).countItems(),
   ]);
+
   const isFirstRun = itemCount === 0;
+  const s = r.summary;
+
+  // Resolve thumbnail availability for the items-in-range table.
+  const itemIds = r.itemProfits.map((p) => p.id);
+  const thumbMap = await userScope(userId).getItemHasThumbnailMap(itemIds);
+
+  const costSlices: CostSlice[] = [
+    { name: "Cost of goods", value: s.cost, color: "var(--brand)" },
+    { name: "Shipping", value: s.shipping, color: "var(--accent-amber)" },
+    { name: "Platform fees", value: s.fees, color: "var(--accent-violet)" },
+    { name: "Other expenses", value: s.totalExpenses, color: "var(--accent-rose)" },
+  ].filter((s) => s.value > 0);
+  const totalCosts = s.cost + s.shipping + s.fees + s.totalExpenses;
 
   return (
     <div className="space-y-8">
-      <header className="flex items-end justify-between">
-        <h1 className="text-2xl font-semibold">Profit</h1>
-        <form className="flex gap-2 text-sm">
-          <select
-            name="preset"
-            defaultValue={preset}
-            className="rounded-md border px-2 py-1.5"
-          >
-            {PRESETS.map((p) => (
-              <option key={p.value} value={p.value}>
-                {p.label}
-              </option>
-            ))}
-          </select>
-          <button className="rounded-md border px-3 py-1.5">Apply</button>
-        </form>
-      </header>
+      <PageHeader
+        title="Profit"
+        subtitle={formatRangeSubtitle(range.from, range.to)}
+        actions={
+          <form className="flex items-center gap-2 text-sm">
+            <select
+              name="preset"
+              defaultValue={preset}
+              className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm text-[var(--text-primary)]"
+            >
+              {PRESETS.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm font-medium hover:bg-[var(--surface-muted)]"
+            >
+              Apply
+            </button>
+          </form>
+        }
+      />
 
       {isFirstRun && (
         <FirstRunNudge
@@ -60,111 +107,415 @@ export default async function ProfitPage({
         />
       )}
 
-      <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <Tile label="Revenue" value={gbp(r.summary.revenue)} />
-        <Tile label="Net profit" value={gbp(r.summary.netProfit)} />
-        <Tile label="Avg margin" value={`${r.summary.avgMargin}%`} />
-        <Tile label="Items sold" value={r.summary.itemsSold.toString()} />
-        <Tile label="Cost of goods" value={gbp(r.summary.cost)} />
-        <Tile label="Shipping" value={gbp(r.summary.shipping)} />
-        <Tile label="Platform fees" value={gbp(r.summary.fees)} />
-        <Tile label="Other expenses" value={gbp(r.summary.totalExpenses)} />
+      {/* What came in */}
+      <section className="space-y-3">
+        <h2 className="text-xs font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          What came in
+        </h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <Tile
+            label="Net profit"
+            value={gbp(s.netProfit)}
+            sub={`${s.avgMargin}% avg margin`}
+            tone="emerald"
+            icon={<TrendIcon />}
+          />
+          <Tile
+            label="Revenue"
+            value={gbp(s.revenue)}
+            sub={`${s.itemsSold} items sold`}
+            tone="brand"
+            icon={<MoneyIcon />}
+          />
+          <Tile
+            label="Items sold"
+            value={num0(s.itemsSold)}
+            sub={s.itemsSold ? `${gbp(s.avgProfitPerItem)} avg profit` : "—"}
+            tone="violet"
+            icon={<TagIcon />}
+          />
+          <Tile
+            label="Sell-through"
+            value={`${s.sellThroughRate}%`}
+            sub={`${s.itemsListed} still listed`}
+            tone="amber"
+            icon={<RotateIcon />}
+          />
+        </div>
       </section>
 
-      <Breakdown
-        title="By category"
-        rows={r.byCategory.map((c) => ({ key: c.category, ...c }))}
-      />
-      <Breakdown
-        title="By source"
-        rows={r.bySource.map((c) => ({ key: c.source, ...c }))}
-      />
-      <Breakdown
-        title="By month"
-        rows={r.byMonth.map((c) => ({ key: c.month, ...c }))}
-      />
+      {/* What went out */}
+      <section className="space-y-3">
+        <h2 className="text-xs font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
+          What went out
+        </h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <Tile
+            label="Cost of goods"
+            value={gbp(s.cost)}
+            tone="brand"
+            icon={<BagIcon />}
+          />
+          <Tile
+            label="Shipping"
+            value={gbp(s.shipping)}
+            tone="amber"
+            icon={<TruckIcon />}
+          />
+          <Tile
+            label="Platform fees"
+            value={gbp(s.fees)}
+            tone="violet"
+            icon={<PercentIcon />}
+          />
+          <Tile
+            label="Other expenses"
+            value={gbp(s.totalExpenses)}
+            tone="rose"
+            icon={<ReceiptIcon />}
+          />
+        </div>
+      </section>
 
+      {/* Charts row: line chart (2/3), donut (1/3), summary card */}
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader
+              title="Revenue vs costs over time"
+              description="Daily revenue, cost of goods and net profit across the selected window."
+            />
+            <div className="mt-4 flex flex-wrap gap-3 text-[11px] text-[var(--text-secondary)]">
+              <LegendDot color="var(--brand)" label="Revenue" />
+              <LegendDot color="var(--accent-rose)" label="Cost" />
+              <LegendDot color="var(--accent-emerald)" label="Net profit" />
+            </div>
+            <div className="mt-2">
+              <RevenueVsCostsChart data={series} />
+            </div>
+          </Card>
+        </div>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader title="Cost composition" />
+            <div className="mt-2">
+              <CostCompositionChart
+                data={costSlices}
+                centerLabel="Total costs"
+                centerValue={gbp(totalCosts)}
+              />
+            </div>
+            {costSlices.length > 0 && (
+              <ul className="mt-3 space-y-1.5 text-xs text-[var(--text-secondary)]">
+                {costSlices.map((c) => (
+                  <li key={c.name} className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full"
+                        style={{ background: c.color }}
+                        aria-hidden
+                      />
+                      {c.name}
+                    </span>
+                    <span className="tabular-nums text-[var(--text-primary)]">{gbp(c.value)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </div>
+      </section>
+
+      {/* Summary card */}
       <section>
-        <h2 className="text-sm font-medium text-gray-600">Items in range</h2>
-        {r.itemProfits.length === 0 ? (
-          <p className="mt-2 text-sm text-gray-500">No sales in this period.</p>
-        ) : (
-          <table className="mt-2 w-full border-collapse text-sm">
-            <thead>
-              <tr className="border-b text-left text-xs uppercase text-gray-500">
-                <th className="py-2 pr-4">Item</th>
-                <th className="py-2 pr-4 text-right">Sold</th>
-                <th className="py-2 pr-4 text-right">Cost</th>
-                <th className="py-2 pr-4 text-right">Net</th>
-                <th className="py-2 pr-4">Sold at</th>
-              </tr>
-            </thead>
-            <tbody>
-              {r.itemProfits.map((p) => (
-                <tr key={p.id} className="border-b">
-                  <td className="py-2 pr-4">
-                    <Link href={`/inventory/${p.id}`} className="underline">
-                      {p.name}
-                    </Link>
-                  </td>
-                  <td className="py-2 pr-4 text-right">{gbp(p.sold)}</td>
-                  <td className="py-2 pr-4 text-right">{gbp(p.cost)}</td>
-                  <td className="py-2 pr-4 text-right font-medium">
-                    {gbp(p.netProfit)}
-                  </td>
-                  <td className="py-2 pr-4 text-xs text-gray-500">
-                    {p.soldAt ? new Date(p.soldAt).toLocaleDateString() : "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+        <Card>
+          <CardHeader title="Summary" description="Totals for the selected period." />
+          <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 text-sm md:grid-cols-4">
+            <SummaryRow label="Revenue" value={gbp(s.revenue)} />
+            <SummaryRow label="Gross profit" value={gbp(s.grossProfit)} />
+            <SummaryRow
+              label="Net profit"
+              value={gbp(s.netProfit)}
+              tone={s.netProfit >= 0 ? "positive" : "negative"}
+            />
+            <SummaryRow label="Avg margin" value={`${s.avgMargin}%`} />
+            <SummaryRow label="Cost of goods" value={gbp(s.cost)} />
+            <SummaryRow label="Shipping" value={gbp(s.shipping)} />
+            <SummaryRow label="Platform fees" value={gbp(s.fees)} />
+            <SummaryRow label="Other expenses" value={gbp(s.totalExpenses)} />
+          </dl>
+        </Card>
+      </section>
+
+      {/* Three breakdown tables + items in range */}
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <BreakdownCard
+          title="By category"
+          rows={r.byCategory.map((c) => ({ key: c.category, ...c }))}
+        />
+        <BreakdownCard
+          title="By source"
+          rows={r.bySource.map((c) => ({ key: c.source, ...c }))}
+        />
+        <BreakdownCard
+          title="By month"
+          rows={r.byMonth.map((c) => ({ key: c.month, ...c }))}
+        />
+        <Card padded={false}>
+          <div className="flex items-center justify-between p-5 pb-3">
+            <h3 className="text-base font-semibold text-[var(--text-primary)]">Items in range</h3>
+            <span className="text-xs text-[var(--text-muted)]">
+              {r.itemProfits.length} {r.itemProfits.length === 1 ? "item" : "items"}
+            </span>
+          </div>
+          {r.itemProfits.length === 0 ? (
+            <p className="px-5 pb-5 text-sm text-[var(--text-muted)]">
+              No sales in this period.
+            </p>
+          ) : (
+            <div className="max-h-[420px] overflow-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead className="sticky top-0 z-10 bg-[var(--surface-muted)]">
+                  <tr className="border-y border-[var(--border-subtle)] text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+                    <th className="py-2 pl-5 pr-3 font-medium">Item</th>
+                    <th className="py-2 pr-3 text-right font-medium">Sold</th>
+                    <th className="py-2 pr-3 text-right font-medium">Cost</th>
+                    <th className="py-2 pr-3 text-right font-medium">Net</th>
+                    <th className="py-2 pr-5 font-medium">Sold at</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {r.itemProfits.map((p) => {
+                    const hasThumbnail = thumbMap.get(p.id) ?? false;
+                    return (
+                      <tr
+                        key={p.id}
+                        className="border-b border-[var(--border-subtle)] last:border-b-0 hover:bg-[var(--surface-muted)]/60"
+                      >
+                        <td className="py-2.5 pl-5 pr-3">
+                          <Link
+                            href={`/inventory/${p.id}`}
+                            className="flex items-center gap-3"
+                          >
+                            <span className="relative inline-flex h-9 w-9 shrink-0 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
+                              {hasThumbnail ? (
+                                <Image
+                                  src={`/api/inventory/thumb/${p.id}`}
+                                  alt=""
+                                  width={36}
+                                  height={36}
+                                  className="h-full w-full object-cover"
+                                  unoptimized
+                                />
+                              ) : (
+                                <span className="m-auto text-[9px] uppercase text-[var(--text-muted)]">
+                                  no img
+                                </span>
+                              )}
+                            </span>
+                            <span className="font-medium text-[var(--text-primary)] hover:underline">
+                              {p.name}
+                            </span>
+                          </Link>
+                        </td>
+                        <td className="py-2.5 pr-3 text-right tabular-nums">{gbp(p.sold)}</td>
+                        <td className="py-2.5 pr-3 text-right tabular-nums text-[var(--text-secondary)]">
+                          {gbp(p.cost)}
+                        </td>
+                        <td
+                          className={`py-2.5 pr-3 text-right font-semibold tabular-nums ${
+                            p.netProfit >= 0
+                              ? "text-[var(--accent-emerald-soft-fg)]"
+                              : "text-[var(--accent-rose-soft-fg)]"
+                          }`}
+                        >
+                          {gbp(p.netProfit)}
+                        </td>
+                        <td className="py-2.5 pr-5 text-xs text-[var(--text-muted)]">
+                          {p.soldAt ? new Date(p.soldAt).toLocaleDateString("en-GB") : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
       </section>
     </div>
   );
 }
 
-function Tile({ label, value }: { label: string; value: string }) {
+function SummaryRow({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "positive" | "negative";
+}) {
+  const valueClass =
+    tone === "positive"
+      ? "text-[var(--accent-emerald-soft-fg)]"
+      : tone === "negative"
+        ? "text-[var(--accent-rose-soft-fg)]"
+        : "text-[var(--text-primary)]";
   return (
-    <div className="rounded-md border p-4">
-      <div className="text-xs uppercase text-gray-500">{label}</div>
-      <div className="mt-1 text-xl font-semibold">{value}</div>
+    <div className="flex flex-col">
+      <dt className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">{label}</dt>
+      <dd className={`mt-1 text-lg font-semibold tabular-nums ${valueClass}`}>{value}</dd>
     </div>
   );
 }
 
-function Breakdown({
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        className="inline-block h-2.5 w-2.5 rounded-full"
+        style={{ background: color }}
+        aria-hidden
+      />
+      {label}
+    </span>
+  );
+}
+
+function BreakdownCard({
   title,
   rows,
 }: {
   title: string;
   rows: { key: string; revenue: number; profit: number; count: number }[];
 }) {
-  if (rows.length === 0) return null;
+  const dimension = title.replace("By ", "");
+  const totalRev = rows.reduce((a, b) => a + b.revenue, 0);
+  const totalProfit = rows.reduce((a, b) => a + b.profit, 0);
+  const totalCount = rows.reduce((a, b) => a + b.count, 0);
   return (
-    <section>
-      <h2 className="text-sm font-medium text-gray-600">{title}</h2>
-      <table className="mt-2 w-full border-collapse text-sm">
-        <thead>
-          <tr className="border-b text-left text-xs uppercase text-gray-500">
-            <th className="py-2 pr-4">{title.replace("By ", "")}</th>
-            <th className="py-2 pr-4 text-right">Items</th>
-            <th className="py-2 pr-4 text-right">Revenue</th>
-            <th className="py-2 pr-4 text-right">Profit</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.key} className="border-b">
-              <td className="py-2 pr-4">{r.key}</td>
-              <td className="py-2 pr-4 text-right">{r.count}</td>
-              <td className="py-2 pr-4 text-right">{gbp(r.revenue)}</td>
-              <td className="py-2 pr-4 text-right font-medium">{gbp(r.profit)}</td>
+    <Card padded={false}>
+      <div className="p-5 pb-3">
+        <h3 className="text-base font-semibold text-[var(--text-primary)] capitalize">
+          {title}
+        </h3>
+      </div>
+      {rows.length === 0 ? (
+        <p className="px-5 pb-5 text-sm text-[var(--text-muted)]">No data.</p>
+      ) : (
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-y border-[var(--border-subtle)] bg-[var(--surface-muted)] text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+              <th className="py-2 pl-5 pr-3 font-medium capitalize">{dimension}</th>
+              <th className="py-2 pr-3 text-right font-medium">Items</th>
+              <th className="py-2 pr-3 text-right font-medium">Revenue</th>
+              <th className="py-2 pr-5 text-right font-medium">Profit</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </section>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr
+                key={row.key}
+                className="border-b border-[var(--border-subtle)] last:border-b-0"
+              >
+                <td className="py-2.5 pl-5 pr-3 text-[var(--text-primary)]">{row.key}</td>
+                <td className="py-2.5 pr-3 text-right tabular-nums text-[var(--text-secondary)]">
+                  {row.count}
+                </td>
+                <td className="py-2.5 pr-3 text-right tabular-nums">{gbp(row.revenue)}</td>
+                <td
+                  className={`py-2.5 pr-5 text-right font-semibold tabular-nums ${
+                    row.profit >= 0
+                      ? "text-[var(--accent-emerald-soft-fg)]"
+                      : "text-[var(--accent-rose-soft-fg)]"
+                  }`}
+                >
+                  {gbp(row.profit)}
+                </td>
+              </tr>
+            ))}
+            <tr className="bg-[var(--surface-muted)]/60">
+              <td className="py-2.5 pl-5 pr-3 text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
+                Total
+              </td>
+              <td className="py-2.5 pr-3 text-right tabular-nums text-[var(--text-secondary)]">
+                {totalCount}
+              </td>
+              <td className="py-2.5 pr-3 text-right font-semibold tabular-nums">
+                {gbp(totalRev)}
+              </td>
+              <td
+                className={`py-2.5 pr-5 text-right font-semibold tabular-nums ${
+                  totalProfit >= 0
+                    ? "text-[var(--accent-emerald-soft-fg)]"
+                    : "text-[var(--accent-rose-soft-fg)]"
+                }`}
+              >
+                {gbp(totalProfit)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}
+
+/* ---- Inline icons ---- */
+function MoneyIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M11 5.5C11 4.67 10.1 4 9 4S7 4.67 7 5.5 7.9 7 9 7s2 .67 2 1.5S10.1 10 9 10s-2-.67-2-1.5M9 3v1M9 10v1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+function TrendIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M3 14l4-4 3 3 5-6M11 7h4v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function TagIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M2.5 9V3h6l7 7-6 6-7-7zM6 6a1 1 0 100-2 1 1 0 000 2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function RotateIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M3 9a6 6 0 0110-4.5L15 6M15 3v3h-3M15 9a6 6 0 01-10 4.5L3 12M3 15v-3h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function BagIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M4 6h10l-1 9H5L4 6zM6 6V4a3 3 0 016 0v2" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function TruckIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M2 5h8v8H2zM10 8h4l2 2v3h-6zM5 15a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM13 15a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function PercentIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M4 14L14 4M5.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM12.5 14a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+function ReceiptIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+      <path d="M4 2v14l2-1.5L8 16l2-1.5 2 1.5 2-1.5V2zM6 6h6M6 9h6M6 12h4" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+    </svg>
   );
 }

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -1,0 +1,144 @@
+import { and, eq, gte, lte } from "drizzle-orm";
+import { db } from "@/db/client";
+import { items, transactions, expenses } from "@/db/schema";
+import type { DateRange } from "@/lib/date-range";
+
+const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+
+export type ProfitSeriesPoint = {
+  /** ISO yyyy-mm-dd */
+  date: string;
+  /** ms-epoch for chart x-axis math */
+  t: number;
+  revenue: number;
+  cost: number;
+  fees: number;
+  shipping: number;
+  expenses: number;
+  netProfit: number;
+};
+
+const DAY_MS = 86400000;
+
+function startOfDay(d: Date) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+/**
+ * Build a daily revenue/cost/profit series across the resolved range.
+ * If the range is open-ended, we clamp to the first sale -> today (or
+ * last 90 days if no sales yet) so the chart has a sensible domain.
+ *
+ * User-scoped: we filter by userId on every table read.
+ */
+export async function computeProfitSeries(
+  userId: string,
+  range: DateRange,
+): Promise<ProfitSeriesPoint[]> {
+  const sold = await db
+    .select({
+      id: items.id,
+      costPrice: items.costPrice,
+      soldPrice: items.soldPrice,
+      soldAt: items.soldAt,
+      status: items.status,
+    })
+    .from(items)
+    .where(eq(items.userId, userId));
+
+  // Clamp range
+  const soldDates = sold
+    .filter((i) => (i.status === "sold" || i.status === "shipped") && i.soldAt)
+    .map((i) => startOfDay(i.soldAt as Date).getTime());
+
+  let from = range.from ? startOfDay(range.from) : null;
+  let to = range.to ? startOfDay(range.to) : null;
+
+  if (!from) {
+    const earliest = soldDates.length ? Math.min(...soldDates) : Date.now() - 89 * DAY_MS;
+    from = startOfDay(new Date(earliest));
+  }
+  if (!to) {
+    to = startOfDay(new Date());
+  }
+  if (to < from) return [];
+
+  const days = Math.floor((to.getTime() - from.getTime()) / DAY_MS) + 1;
+  const points: ProfitSeriesPoint[] = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date(from.getTime() + i * DAY_MS);
+    points.push({
+      date: d.toISOString().slice(0, 10),
+      t: d.getTime(),
+      revenue: 0,
+      cost: 0,
+      fees: 0,
+      shipping: 0,
+      expenses: 0,
+      netProfit: 0,
+    });
+  }
+  const idxFor = (d: Date) => {
+    const day = startOfDay(d).getTime();
+    const i = Math.floor((day - from!.getTime()) / DAY_MS);
+    return i >= 0 && i < points.length ? i : -1;
+  };
+
+  // Item-level sale data
+  const itemBy: Record<string, { idx: number; cost: number; sold: number }> = {};
+  for (const it of sold) {
+    if (it.status !== "sold" && it.status !== "shipped") continue;
+    if (!it.soldAt) continue;
+    const i = idxFor(it.soldAt as Date);
+    if (i < 0) continue;
+    const s = num(it.soldPrice);
+    const c = num(it.costPrice);
+    points[i].revenue += s;
+    points[i].cost += c;
+    itemBy[it.id] = { idx: i, cost: c, sold: s };
+  }
+
+  // Transactions for fees / shipping
+  const itemIds = Object.keys(itemBy);
+  if (itemIds.length) {
+    const txns = await db
+      .select({
+        itemId: transactions.itemId,
+        shippingCost: transactions.shippingCost,
+        platformFees: transactions.platformFees,
+      })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.userId, userId),
+          eq(transactions.transactionType, "sell"),
+        ),
+      );
+    for (const t of txns) {
+      const ref = itemBy[t.itemId];
+      if (!ref) continue;
+      points[ref.idx].fees += num(t.platformFees);
+      points[ref.idx].shipping += num(t.shippingCost);
+    }
+  }
+
+  // Business expenses in window
+  const expConds = [eq(expenses.userId, userId), gte(expenses.incurredAt, from), lte(expenses.incurredAt, to)];
+  const exps = await db
+    .select({ amount: expenses.amount, incurredAt: expenses.incurredAt })
+    .from(expenses)
+    .where(and(...expConds));
+  for (const e of exps) {
+    const i = idxFor(e.incurredAt as Date);
+    if (i < 0) continue;
+    points[i].expenses += num(e.amount);
+  }
+
+  for (const p of points) {
+    p.netProfit = p.revenue - p.cost - p.fees - p.shipping - p.expenses;
+  }
+
+  return points;
+}


### PR DESCRIPTION
## Summary
- Rebuilds `/profit` to match `Layout/06-profit.png`: PageHeader + preset selector, two grouped tile rows ("What came in" / "What went out"), Recharts revenue-vs-costs area chart, donut cost composition, summary card, three breakdown tables, and items-in-range table with thumbnails.
- Adds `computeProfitSeries` (user-scoped daily series for revenue/cost/fees/shipping/expenses/netProfit) alongside the existing `computeProfit`.
- Items table uses the `hasThumbnail` + `/api/inventory/thumb/[id]` pattern from #20 — no photo blobs selected.

## Test plan
- [ ] Visit `/profit?preset=this_month` — tiles match summary, charts render
- [ ] Switch to "Last 90 days" / "All time" — chart domain adapts, tables update
- [ ] Item rows link to `/inventory/[id]` and show thumbnails when present
- [ ] No console errors, no `db.select().from(items)` without explicit columns
- [ ] `pnpm build` passes locally

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)