### PR TITLE
Inventory list: row-level mark sold/shipped (#38)

### DIFF
--- a/src/app/(app)/inventory/MarkAsSoldPopover.tsx
+++ b/src/app/(app)/inventory/MarkAsSoldPopover.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  useTransition,
+  type FormEvent,
+} from "react";
+import { markItemSoldAction } from "./status-actions";
+
+/**
+ * Compact "Mark as sold" chip with an anchored popover. Two inputs only:
+ * Sold price + Shipping. No fees field — Vinted does not charge sellers
+ * (see AGENTS.md). The popover is absolutely positioned, so it overlays
+ * surrounding content and never grows the page (no-scroll rule).
+ *
+ * Designed to be reusable: anywhere a row needs a "Mark as sold" affordance
+ * with sale inputs, drop this in. /plan can reuse it later.
+ */
+export function MarkAsSoldPopover({
+  itemId,
+  defaultSoldPrice,
+}: {
+  itemId: string;
+  defaultSoldPrice?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const firstFieldRef = useRef<HTMLInputElement | null>(null);
+  const priceId = useId();
+  const shipId = useId();
+
+  // Click-outside + Escape to close.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Focus the price field when opened.
+  useEffect(() => {
+    if (open) {
+      requestAnimationFrame(() => firstFieldRef.current?.focus());
+    } else {
+      setError(null);
+    }
+  }, [open]);
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const soldPrice = String(fd.get("soldPrice") ?? "");
+    const shipping = String(fd.get("shipping") ?? "");
+    setError(null);
+    startTransition(async () => {
+      const result = await markItemSoldAction(itemId, soldPrice, shipping);
+      if (result.ok) {
+        setOpen(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <div ref={wrapRef} className="relative inline-block">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-default)] hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"
+      >
+        Mark as sold
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Mark as sold"
+          className="absolute right-0 top-full z-30 mt-1 w-64 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] p-3 shadow-lg"
+        >
+          <form onSubmit={onSubmit} className="space-y-2">
+            <div className="space-y-1">
+              <label
+                htmlFor={priceId}
+                className="block text-[11px] font-medium text-[var(--text-secondary)]"
+              >
+                Sold price (£)
+              </label>
+              <input
+                ref={firstFieldRef}
+                id={priceId}
+                name="soldPrice"
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                required
+                defaultValue={defaultSoldPrice ?? ""}
+                className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor={shipId}
+                className="block text-[11px] font-medium text-[var(--text-secondary)]"
+              >
+                Shipping (£)
+              </label>
+              <input
+                id={shipId}
+                name="shipping"
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                min="0"
+                defaultValue="0"
+                className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-1.5 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
+              />
+            </div>
+            {error && (
+              <p className="text-[11px] text-[var(--accent-rose)]">{error}</p>
+            )}
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-[var(--radius-sm)] px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--surface-muted)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded-[var(--radius-sm)] border border-transparent bg-[var(--brand)] px-2.5 py-1 text-[11px] font-medium text-white hover:bg-[var(--brand-hover)] disabled:opacity-50"
+              >
+                {pending ? "Saving…" : "Confirm"}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/inventory/StatusTransitionButton.tsx
+++ b/src/app/(app)/inventory/StatusTransitionButton.tsx
@@ -2,28 +2,40 @@
 
 import { useTransition } from "react";
 import { transitionItemStatusAction } from "./status-actions";
+import { MarkAsSoldPopover } from "./MarkAsSoldPopover";
 
 type Status = "sourced" | "listed" | "sold" | "shipped";
 
-const NEXT_LABEL: Partial<Record<Status, { label: string; next: Status }>> = {
+const ONE_TAP: Partial<Record<Status, { label: string; next: Status }>> = {
   sourced: { label: "Mark as listed", next: "listed" },
   sold: { label: "Mark as shipped", next: "shipped" },
 };
 
 /**
- * Inline action chip for a single-tap status transition from the inventory
- * list. Renders nothing for statuses without a meaningful next-step from this
- * surface (listed → sold needs a sale price; shipped is terminal).
+ * Inline action chip for a row's next status transition. Three forms:
+ *   sourced → listed   one-tap chip
+ *   listed  → sold     chip with anchored popover (sold price + shipping)
+ *   sold    → shipped  one-tap chip
+ *   shipped            no action (terminal)
  */
 export function StatusTransitionButton({
   itemId,
   status,
+  listedPrice,
 }: {
   itemId: string;
   status: string;
+  listedPrice?: string | null;
 }) {
   const [pending, startTransition] = useTransition();
-  const def = NEXT_LABEL[status as Status];
+
+  if (status === "listed") {
+    return (
+      <MarkAsSoldPopover itemId={itemId} defaultSoldPrice={listedPrice} />
+    );
+  }
+
+  const def = ONE_TAP[status as Status];
   if (!def) return null;
 
   return (

--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -257,8 +257,8 @@ function Thumb({ row, size = 40 }: { row: Row; size?: number }) {
 
 function TableView({ rows }: { rows: Row[] }) {
   return (
-    <Card padded={false} className="overflow-hidden">
-      <div className="overflow-x-auto">
+    <Card padded={false} className="overflow-visible">
+      <div>
         <table className="w-full border-collapse text-sm">
           <thead>
             <tr className="border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]/40 text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
@@ -320,7 +320,11 @@ function TableView({ rows }: { rows: Row[] }) {
                   {gbp(r.soldPrice)}
                 </td>
                 <td className="py-3 pr-4">
-                  <StatusTransitionButton itemId={r.id} status={r.status} />
+                  <StatusTransitionButton
+                    itemId={r.id}
+                    status={r.status}
+                    listedPrice={r.listedPrice}
+                  />
                 </td>
               </tr>
             ))}
@@ -378,7 +382,11 @@ function GridView({ rows }: { rows: Row[] }) {
                 </span>
               </div>
               <div className="flex justify-end">
-                <StatusTransitionButton itemId={r.id} status={r.status} />
+                <StatusTransitionButton
+                    itemId={r.id}
+                    status={r.status}
+                    listedPrice={r.listedPrice}
+                  />
               </div>
             </div>
           </Card>

--- a/src/app/(app)/inventory/status-actions.ts
+++ b/src/app/(app)/inventory/status-actions.ts
@@ -6,15 +6,80 @@ import { userScope } from "@/lib/db/scoped";
 
 type Status = "sourced" | "listed" | "sold" | "shipped";
 
+function parseMoney(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n.toFixed(2);
+}
+
+/**
+ * Mark an item as sold from the inventory list. Mirrors the sold-side logic of
+ * PATCH /api/inventory/[id]: stamps soldAt, sets soldPrice, and auto-creates a
+ * sell transaction. Vinted has no seller fees (see AGENTS.md), so we never
+ * surface or accept a fees input — platformFees is always 0.
+ */
+export async function markItemSoldAction(
+  id: string,
+  rawSoldPrice: string,
+  rawShipping: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { userId } = await auth();
+  if (!userId) return { ok: false, error: "Not signed in" };
+
+  const soldPrice = parseMoney(rawSoldPrice);
+  if (soldPrice === null) {
+    return { ok: false, error: "Enter a sold price" };
+  }
+  const shipping = parseMoney(rawShipping) ?? "0.00";
+
+  const scope = userScope(userId);
+  const existing = await scope.getItem(id);
+  if (!existing) return { ok: false, error: "Not found" };
+
+  if (existing.status === "sold" || existing.status === "shipped") {
+    return { ok: false, error: "Already sold" };
+  }
+
+  const now = new Date();
+  const updates: Record<string, unknown> = {
+    status: "sold" as Status,
+    soldPrice,
+  };
+  if (!existing.soldAt) updates.soldAt = now;
+
+  const [updated] = await scope.updateItem(id, updates);
+
+  const cost = updated.costPrice ?? "0";
+  const profit = (
+    Number(soldPrice) - Number(cost) - Number(shipping)
+  ).toFixed(2);
+
+  await scope.insertTransaction({
+    itemId: id,
+    transactionType: "sell",
+    grossPrice: soldPrice,
+    shippingCost: shipping,
+    platformFees: "0",
+    profit,
+    completedAt: now,
+  });
+
+  revalidatePath("/inventory");
+  revalidatePath(`/inventory/${id}`);
+  revalidatePath("/dashboard");
+  return { ok: true };
+}
+
 /**
  * One-tap inventory status transition. Mirrors the timestamp logic of the
  * PATCH /api/inventory/[id] route so that "Mark as listed" from the inventory
  * list behaves identically to changing status on the detail page.
  *
- * Note: we deliberately don't auto-create a sell transaction here. A "Mark as
- * sold" tap from the list has no shipping/fees context — the detail page is
- * still the right place for that flow. The list is for low-friction
- * sourced→listed and sold→shipped transitions.
+ * Note: this helper does NOT auto-create a sell transaction. The listed→sold
+ * transition has its own action (markItemSoldAction) because it needs sale
+ * inputs. Use this for sourced→listed and sold→shipped one-tap transitions.
  */
 export async function transitionItemStatusAction(
   id: string,


### PR DESCRIPTION
## Summary

- Adds row-level status chips on `/inventory` so users can advance items through their lifecycle without opening the detail page.
  - `sourced` → one-tap *Mark as listed*
  - `listed` → *Mark as sold* chip opens an anchored popover with two inputs (sold price + shipping). Confirming runs a server action that mirrors the PATCH route's sold path — stamps `soldAt`, sets `soldPrice`, and auto-creates the sell transaction.
  - `sold` → one-tap *Mark as shipped*
  - `shipped` → no action
- New `MarkAsSoldPopover.tsx` is colocated and intentionally generic, so `/plan` can reuse it later.

## Constraints honored

- **No fees field** anywhere in the popover or server action — Vinted does not charge sellers (AGENTS.md). `platformFees` is hardcoded to `"0"` for the auto-created transaction.
- **No-scroll preserved**. Popover is absolutely positioned (`top-full right-0`) and overlays surrounding content; it never grows the page. Verified the inventory list still fits 1280×800 without vertical page scroll.
- Tenancy: server action goes through `userScope(userId)`.
- No new deps, no Turbopack, only existing UI primitives + tokens.

## Test plan

- [ ] On `/inventory`, sourced rows show *Mark as listed* and one-tap promotes to listed.
- [ ] Listed rows show *Mark as sold*; clicking opens an inline popover with sold price (defaulted to listed price) and shipping inputs, no fees field.
- [ ] Confirming the popover transitions the item to sold, stamps soldAt, persists soldPrice, and creates a sell transaction with `platformFees=0`.
- [ ] Sold rows show *Mark as shipped* and one-tap promotes to shipped.
- [ ] Shipped rows show no action chip.
- [ ] At 1280×800 the page does not scroll vertically; popover overlays content.
- [ ] Escape and click-outside close the popover.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)