### PR TITLE
Strip seller fees from app (Vinted-no-fees rule) (#40)

### DIFF
--- a/src/app/(app)/expenses/client.tsx
+++ b/src/app/(app)/expenses/client.tsx
@@ -15,7 +15,6 @@ const CATEGORIES = [
   "shipping_supplies",
   "packaging",
   "promotion",
-  "platform_fee",
   "other",
 ];
 

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -39,7 +39,7 @@ export default async function ExpensesPage({
         <div>
           <h1 className="text-2xl font-semibold">Expenses</h1>
           <p className="mt-1 text-sm text-gray-600">
-            Business costs: packaging, supplies, fees.
+            Business costs: packaging and shipping supplies.
           </p>
         </div>
         <form className="flex gap-2 text-sm">

--- a/src/app/(app)/inventory/[id]/actions.tsx
+++ b/src/app/(app)/inventory/[id]/actions.tsx
@@ -31,15 +31,13 @@ export function ItemActions({
   const [sell, setSell] = useState({
     soldPrice: soldPrice ?? listedPrice ?? "",
     shippingCost: "0",
-    platformFees: "0",
   });
 
   const estimatedProfit = useMemo(() => {
     const gross = gbpNum(sell.soldPrice);
     const ship = gbpNum(sell.shippingCost);
-    const fees = gbpNum(sell.platformFees);
     const cost = gbpNum(costPrice);
-    return gross - ship - fees - cost;
+    return gross - ship - cost;
   }, [sell, costPrice]);
 
   async function transition(next: Status) {
@@ -56,7 +54,6 @@ export function ItemActions({
       status: "sold",
       soldPrice: sell.soldPrice || null,
       shippingCost: sell.shippingCost || "0",
-      platformFees: sell.platformFees || "0",
     });
     setShowSell(false);
   }
@@ -133,7 +130,7 @@ export function ItemActions({
             </div>
           </div>
 
-          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Field label="Sold price (£)">
               <input
                 type="number"
@@ -153,17 +150,6 @@ export function ItemActions({
                 value={sell.shippingCost}
                 onChange={(e) =>
                   setSell({ ...sell, shippingCost: e.target.value })
-                }
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
-              />
-            </Field>
-            <Field label="Platform fees (£)">
-              <input
-                type="number"
-                step="0.01"
-                value={sell.platformFees}
-                onChange={(e) =>
-                  setSell({ ...sell, platformFees: e.target.value })
                 }
                 className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
               />

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -163,7 +163,6 @@ export default async function ItemDetail({
                   <th className="px-5 py-2.5 font-medium">Type</th>
                   <th className="px-3 py-2.5 font-medium">Gross</th>
                   <th className="px-3 py-2.5 font-medium">Shipping</th>
-                  <th className="px-3 py-2.5 font-medium">Fees</th>
                   <th className="px-3 py-2.5 font-medium">Profit</th>
                   <th className="px-5 py-2.5 font-medium">Completed</th>
                 </tr>
@@ -191,9 +190,6 @@ export default async function ItemDetail({
                       </td>
                       <td className="px-3 py-3 text-[var(--text-secondary)]">
                         {gbp(t.shippingCost)}
-                      </td>
-                      <td className="px-3 py-3 text-[var(--text-secondary)]">
-                        {gbp(t.platformFees)}
                       </td>
                       <td
                         className={`px-3 py-3 font-medium ${

--- a/src/app/(app)/inventory/status-actions.ts
+++ b/src/app/(app)/inventory/status-actions.ts
@@ -12,7 +12,7 @@ type Status = "sourced" | "listed" | "sold" | "shipped";
  * list behaves identically to changing status on the detail page.
  *
  * Note: we deliberately don't auto-create a sell transaction here. A "Mark as
- * sold" tap from the list has no shipping/fees context — the detail page is
+ * sold" tap from the list has no shipping context — the detail page is
  * still the right place for that flow. The list is for low-friction
  * sourced→listed and sold→shipped transitions.
  */

--- a/src/app/(app)/menu/page.tsx
+++ b/src/app/(app)/menu/page.tsx
@@ -18,7 +18,7 @@ const SECTIONS: Array<{
   {
     title: "Operations",
     items: [
-      { href: "/expenses", label: "Expenses", description: "Packaging, shipping supplies, fees." },
+      { href: "/expenses", label: "Expenses", description: "Packaging and shipping supplies." },
     ],
   },
   {

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -67,10 +67,9 @@ export default async function ProfitPage({
   const costSlices: CostSlice[] = [
     { name: "Cost of goods", value: s.cost, color: "var(--brand)" },
     { name: "Shipping", value: s.shipping, color: "var(--accent-amber)" },
-    { name: "Platform fees", value: s.fees, color: "var(--accent-violet)" },
     { name: "Other expenses", value: s.totalExpenses, color: "var(--accent-rose)" },
   ].filter((s) => s.value > 0);
-  const totalCosts = s.cost + s.shipping + s.fees + s.totalExpenses;
+  const totalCosts = s.cost + s.shipping + s.totalExpenses;
 
   return (
     <div className="space-y-8">
@@ -149,7 +148,7 @@ export default async function ProfitPage({
         <h2 className="text-xs font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
           What went out
         </h2>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
           <Tile
             label="Cost of goods"
             value={gbp(s.cost)}
@@ -161,12 +160,6 @@ export default async function ProfitPage({
             value={gbp(s.shipping)}
             tone="amber"
             icon={<TruckIcon />}
-          />
-          <Tile
-            label="Platform fees"
-            value={gbp(s.fees)}
-            tone="violet"
-            icon={<PercentIcon />}
           />
           <Tile
             label="Other expenses"
@@ -241,7 +234,6 @@ export default async function ProfitPage({
             <SummaryRow label="Avg margin" value={`${s.avgMargin}%`} />
             <SummaryRow label="Cost of goods" value={gbp(s.cost)} />
             <SummaryRow label="Shipping" value={gbp(s.shipping)} />
-            <SummaryRow label="Platform fees" value={gbp(s.fees)} />
             <SummaryRow label="Other expenses" value={gbp(s.totalExpenses)} />
           </dl>
         </Card>
@@ -502,13 +494,6 @@ function TruckIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
       <path d="M2 5h8v8H2zM10 8h4l2 2v3h-6zM5 15a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM13 15a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
-    </svg>
-  );
-}
-function PercentIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
-      <path d="M4 14L14 4M5.5 7a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM12.5 14a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   );
 }

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -36,7 +36,6 @@ const PatchSchema = z.object({
   thumbnailUrl: z.string().nullish(),
   status: z.enum(["sourced", "listed", "sold", "shipped"]).optional(),
   shippingCost: numStr, // for the auto-created sell tx
-  platformFees: numStr, // for the auto-created sell tx
 });
 
 export async function GET(
@@ -78,7 +77,7 @@ export async function PATCH(
   const now = new Date();
   const updates: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(data)) {
-    if (k === "shippingCost" || k === "platformFees") continue;
+    if (k === "shippingCost") continue;
     if (v !== undefined) updates[k] = v;
   }
 
@@ -95,10 +94,9 @@ export async function PATCH(
   if (data.status === "sold" && existing.status !== "sold") {
     const gross = data.soldPrice ?? updated.soldPrice ?? updated.listedPrice ?? "0";
     const shipping = data.shippingCost ?? "0";
-    const fees = data.platformFees ?? "0";
     const cost = updated.costPrice ?? "0";
     const profit = (
-      Number(gross) - Number(cost) - Number(shipping) - Number(fees)
+      Number(gross) - Number(cost) - Number(shipping)
     ).toFixed(2);
 
     await scope.insertTransaction({
@@ -106,7 +104,7 @@ export async function PATCH(
       transactionType: "sell",
       grossPrice: String(gross),
       shippingCost: String(shipping),
-      platformFees: String(fees),
+      platformFees: "0",
       profit,
       completedAt: now,
     });

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -80,7 +80,6 @@ export async function computeBestsellers(userId: string, range: DateRange) {
         .select({
           itemId: transactions.itemId,
           shippingCost: transactions.shippingCost,
-          platformFees: transactions.platformFees,
         })
         .from(transactions)
         .where(
@@ -98,8 +97,7 @@ export async function computeBestsellers(userId: string, range: DateRange) {
     const soldPrice = num(r.soldPrice);
     const tx = txByItem.get(r.id);
     const shipping = num(tx?.shippingCost);
-    const fees = num(tx?.platformFees);
-    const netProfit = soldPrice - cost - shipping - fees;
+    const netProfit = soldPrice - cost - shipping;
     const marginPct = soldPrice > 0 ? (netProfit / soldPrice) * 100 : 0;
     const days = Math.max(
       0,

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -12,7 +12,6 @@ export type ProfitSeriesPoint = {
   t: number;
   revenue: number;
   cost: number;
-  fees: number;
   shipping: number;
   expenses: number;
   netProfit: number;
@@ -74,7 +73,6 @@ export async function computeProfitSeries(
       t: d.getTime(),
       revenue: 0,
       cost: 0,
-      fees: 0,
       shipping: 0,
       expenses: 0,
       netProfit: 0,
@@ -100,14 +98,13 @@ export async function computeProfitSeries(
     itemBy[it.id] = { idx: i, cost: c, sold: s };
   }
 
-  // Transactions for fees / shipping
+  // Transactions for shipping
   const itemIds = Object.keys(itemBy);
   if (itemIds.length) {
     const txns = await db
       .select({
         itemId: transactions.itemId,
         shippingCost: transactions.shippingCost,
-        platformFees: transactions.platformFees,
       })
       .from(transactions)
       .where(
@@ -119,7 +116,6 @@ export async function computeProfitSeries(
     for (const t of txns) {
       const ref = itemBy[t.itemId];
       if (!ref) continue;
-      points[ref.idx].fees += num(t.platformFees);
       points[ref.idx].shipping += num(t.shippingCost);
     }
   }
@@ -137,7 +133,7 @@ export async function computeProfitSeries(
   }
 
   for (const p of points) {
-    p.netProfit = p.revenue - p.cost - p.fees - p.shipping - p.expenses;
+    p.netProfit = p.revenue - p.cost - p.shipping - p.expenses;
   }
 
   return points;

--- a/src/lib/analytics/profit.ts
+++ b/src/lib/analytics/profit.ts
@@ -60,7 +60,6 @@ export async function computeProfit(userId: string, range: DateRange) {
   let revenue = 0;
   let cost = 0;
   let shipping = 0;
-  let fees = 0;
 
   const byCategory = new Map<string, { revenue: number; profit: number; count: number }>();
   const bySource = new Map<string, { revenue: number; profit: number; count: number }>();
@@ -80,13 +79,11 @@ export async function computeProfit(userId: string, range: DateRange) {
     const s = num(it.soldPrice);
     const tx = txByItem.get(it.id);
     const sh = num(tx?.shippingCost ?? null);
-    const fe = num(tx?.platformFees ?? null);
-    const net = s - c - sh - fe;
+    const net = s - c - sh;
 
     revenue += s;
     cost += c;
     shipping += sh;
-    fees += fe;
 
     const cat = it.category || "uncategorised";
     const src = it.sourceType || "unknown";
@@ -129,7 +126,7 @@ export async function computeProfit(userId: string, range: DateRange) {
   }
 
   const grossProfit = revenue - cost;
-  const netProfit = grossProfit - shipping - fees - totalExpenses;
+  const netProfit = grossProfit - shipping - totalExpenses;
 
   // Always-current stock value (not date-filtered)
   let stockCost = 0;
@@ -151,7 +148,6 @@ export async function computeProfit(userId: string, range: DateRange) {
       grossProfit: round(grossProfit),
       netProfit: round(netProfit),
       shipping: round(shipping),
-      fees: round(fees),
       totalExpenses: round(totalExpenses),
       itemsSold: sold.length,
       itemsListed: listed.length,

--- a/src/lib/sample-data.ts
+++ b/src/lib/sample-data.ts
@@ -16,7 +16,6 @@ type SampleItem = {
   daysAgoListed?: number;
   daysAgoSold?: number;
   shippingCost?: string;
-  platformFees?: string;
 };
 
 const SAMPLES: SampleItem[] = [
@@ -34,7 +33,6 @@ const SAMPLES: SampleItem[] = [
     daysAgoListed: 28,
     daysAgoSold: 4,
     shippingCost: "3.50",
-    platformFees: "2.10",
   },
   {
     name: "Zara Wool Coat",
@@ -62,7 +60,6 @@ const SAMPLES: SampleItem[] = [
     daysAgoListed: 58,
     daysAgoSold: 14,
     shippingCost: "3.20",
-    platformFees: "1.25",
   },
   {
     name: "Uniqlo Heattech Crew",
@@ -113,7 +110,6 @@ const SAMPLES: SampleItem[] = [
     daysAgoListed: 48,
     daysAgoSold: 7,
     shippingCost: "3.20",
-    platformFees: "1.00",
   },
   {
     name: "Mango Trench Coat",
@@ -215,9 +211,8 @@ export async function seedSampleData(userId: string): Promise<{
     if (s.status === "sold" && s.soldPrice && soldAt) {
       const gross = parseFloat(s.soldPrice);
       const ship = parseFloat(s.shippingCost ?? "0");
-      const fees = parseFloat(s.platformFees ?? "0");
       const cost = parseFloat(s.costPrice);
-      const profit = (gross - ship - fees - cost).toFixed(2);
+      const profit = (gross - ship - cost).toFixed(2);
 
       await db.insert(transactions).values({
         userId,
@@ -225,7 +220,7 @@ export async function seedSampleData(userId: string): Promise<{
         transactionType: "sell",
         grossPrice: s.soldPrice,
         shippingCost: s.shippingCost ?? "0",
-        platformFees: s.platformFees ?? "0",
+        platformFees: "0",
         profit,
         completedAt: soldAt,
         isSample: true,


### PR DESCRIPTION
## Summary

Vinted does not charge sellers any fees. Per the new AGENTS.md rule, this PR strips all "fees" UI and calculation across the app.

The `transactions.platformFees` column is retained as a dead, default-zero field — no migration. Existing rows with non-zero fees still load; the UI just no longer surfaces or sums them.

Closes #40

## Behavior changes

- **Sale form** (`inventory/[id]/actions.tsx`): "Platform fees (£)" input removed. Estimated profit = sold − shipping − cost.
- **PATCH `/api/inventory/[id]`**: drops `platformFees` from the schema; auto-created sell transactions write `platformFees: "0"` and compute profit without fees.
- **Profit analytics** (`profit.ts`, `profit-series.ts`, `bestsellers.ts`): fees term removed from net-profit math everywhere. Net profit = revenue − cost − shipping − expenses.
- **Profit page**: "Platform fees" tile removed from "What went out" (now 3 tiles), donut "Platform fees" slice removed, summary row removed.
- **Expenses**: `platform_fee` removed from category options. Page subtitle and menu description updated to drop "fees".
- **Item detail transactions table**: "Fees" column removed.
- **Sample data**: `platformFees` field stripped from samples; sell transactions still write `platformFees: "0"` for the schema column.

## Files touched

- src/app/(app)/inventory/[id]/actions.tsx
- src/app/(app)/inventory/[id]/page.tsx
- src/app/(app)/inventory/status-actions.ts (stale comment)
- src/app/api/inventory/[id]/route.ts
- src/app/(app)/profit/page.tsx
- src/app/(app)/expenses/page.tsx
- src/app/(app)/expenses/client.tsx
- src/app/(app)/menu/page.tsx
- src/lib/analytics/profit.ts
- src/lib/analytics/profit-series.ts
- src/lib/analytics/bestsellers.ts
- src/lib/sample-data.ts

## Test plan

- [ ] `pnpm exec tsc --noEmit` clean (verified locally)
- [ ] `pnpm build` succeeds (verified locally with .env.local)
- [ ] `grep -iE '\bfees?\b' src/` returns only the schema column reference and nothing else
- [ ] Mark-as-sold on an item: form shows only Sold/Shipping; profit math correct
- [ ] Profit page: 3 cost tiles (no Platform fees), donut + summary match
- [ ] Expenses page: dropdown no longer offers `platform_fee`
- [ ] Existing transactions with non-zero `platformFees` still load without UI errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)