### PR TITLE
Item detail: fit 1280x800 without scroll (#39)

### DIFF
--- a/src/app/(app)/inventory/[id]/actions.tsx
+++ b/src/app/(app)/inventory/[id]/actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui";
 
@@ -28,6 +28,8 @@ export function ItemActions({
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [showSell, setShowSell] = useState(false);
+  const [showMore, setShowMore] = useState(false);
+  const sellWrapRef = useRef<HTMLDivElement | null>(null);
   const [sell, setSell] = useState({
     soldPrice: soldPrice ?? listedPrice ?? "",
     shippingCost: "0",
@@ -39,6 +41,23 @@ export function ItemActions({
     const cost = gbpNum(costPrice);
     return gross - ship - cost;
   }, [sell, costPrice]);
+
+  // Click-outside / Escape closes the sell popover.
+  useEffect(() => {
+    if (!showSell) return;
+    function onDown(e: MouseEvent) {
+      if (!sellWrapRef.current?.contains(e.target as Node)) setShowSell(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setShowSell(false);
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [showSell]);
 
   async function transition(next: Status) {
     if (next === "sold") {
@@ -85,109 +104,214 @@ export function ItemActions({
   const primary = primaryByStatus[status as Status];
   const secondary = secondaryByStatus[status as Status];
 
-  if (!primary && !secondary && !showSell) {
-    return null;
-  }
-
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2">
-        {primary && (
+    <div className="flex items-center justify-between gap-2">
+      <div ref={sellWrapRef} className="relative flex-1">
+        {primary ? (
           <Button
             disabled={busy}
             onClick={() => transition(primary.next)}
             variant="primary"
             size="md"
+            className="w-full"
           >
             {primary.label}
           </Button>
+        ) : (
+          <p className="text-xs text-[var(--text-muted)]">
+            No further actions — item shipped.
+          </p>
         )}
-        {secondary && (
-          <Button
-            disabled={busy}
-            onClick={() => transition(secondary.next)}
-            variant="secondary"
-            size="md"
+
+        {showSell && (
+          <div
+            role="dialog"
+            aria-label="Mark as sold"
+            className="absolute left-0 right-0 top-full z-30 mt-2 rounded-[var(--radius-lg)] border border-[var(--border-default)] bg-[var(--surface-card)] p-4 shadow-lg"
           >
-            {secondary.label}
-          </Button>
+            <form onSubmit={confirmSell} className="space-y-3">
+              <div>
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                  Mark as sold
+                </h3>
+                <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                  Records the sale and updates profit.
+                </p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Sold price (£)">
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={sell.soldPrice}
+                    onChange={(e) =>
+                      setSell({ ...sell, soldPrice: e.target.value })
+                    }
+                    required
+                    autoFocus
+                    className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-1.5 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
+                  />
+                </Field>
+                <Field label="Shipping (£)">
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={sell.shippingCost}
+                    onChange={(e) =>
+                      setSell({ ...sell, shippingCost: e.target.value })
+                    }
+                    className="w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-1.5 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
+                  />
+                </Field>
+              </div>
+
+              <div className="flex items-center justify-between rounded-[var(--radius-sm)] bg-[var(--surface-muted)] px-2 py-1.5 text-xs">
+                <span className="text-[var(--text-secondary)]">
+                  Est. profit
+                </span>
+                <span
+                  className={`font-semibold ${
+                    estimatedProfit >= 0
+                      ? "text-[var(--accent-emerald-soft-fg)]"
+                      : "text-[var(--accent-rose-soft-fg)]"
+                  }`}
+                >
+                  £{estimatedProfit.toFixed(2)}
+                </span>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowSell(false)}
+                  disabled={busy}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  disabled={busy}
+                >
+                  Confirm sale
+                </Button>
+              </div>
+            </form>
+          </div>
         )}
       </div>
 
-      {showSell && (
-        <form
-          onSubmit={confirmSell}
-          className="rounded-[var(--radius-lg)] border border-[var(--accent-amber)]/40 bg-[var(--accent-amber-soft)] p-5"
+      <div className="relative">
+        <button
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={showMore}
+          onClick={() => setShowMore((v) => !v)}
+          className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-2 py-2 text-sm text-[var(--text-secondary)] hover:border-[var(--border-default)] hover:text-[var(--text-primary)]"
         >
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <h3 className="text-base font-semibold text-[var(--accent-amber-soft-fg)]">
-                Mark as sold
-              </h3>
-              <p className="mt-0.5 text-xs text-[var(--accent-amber-soft-fg)]/80">
-                Record the sale to update profit and transactions.
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Field label="Sold price (£)">
-              <input
-                type="number"
-                step="0.01"
-                value={sell.soldPrice}
-                onChange={(e) =>
-                  setSell({ ...sell, soldPrice: e.target.value })
+          More
+        </button>
+        {showMore && (
+          <MoreMenu onClose={() => setShowMore(false)}>
+            {secondary && (
+              <MenuItem
+                onClick={() => {
+                  setShowMore(false);
+                  transition(secondary.next);
+                }}
+                disabled={busy}
+              >
+                {secondary.label}
+              </MenuItem>
+            )}
+            <MenuItem
+              onClick={async () => {
+                setShowMore(false);
+                if (!confirm("Delete this item and its transactions?")) return;
+                setBusy(true);
+                try {
+                  const res = await fetch(`/api/inventory/${id}`, {
+                    method: "DELETE",
+                  });
+                  if (res.ok) router.push("/inventory");
+                } finally {
+                  setBusy(false);
                 }
-                required
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
-              />
-            </Field>
-            <Field label="Shipping (£)">
-              <input
-                type="number"
-                step="0.01"
-                value={sell.shippingCost}
-                onChange={(e) =>
-                  setSell({ ...sell, shippingCost: e.target.value })
-                }
-                className="w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-white px-3 py-2 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand)]/30"
-              />
-            </Field>
-          </div>
-
-          <div className="mt-4 flex items-center justify-between rounded-[var(--radius-md)] bg-white/60 px-3 py-2 text-sm">
-            <span className="text-[var(--accent-amber-soft-fg)]">
-              Estimated profit
-            </span>
-            <span
-              className={`font-semibold ${
-                estimatedProfit >= 0
-                  ? "text-[var(--accent-emerald-soft-fg)]"
-                  : "text-[var(--accent-rose-soft-fg)]"
-              }`}
-            >
-              £{estimatedProfit.toFixed(2)}
-            </span>
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Button type="submit" variant="primary" size="md" disabled={busy}>
-              Confirm sale
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="md"
-              onClick={() => setShowSell(false)}
+              }}
               disabled={busy}
+              destructive
             >
-              Cancel
-            </Button>
-          </div>
-        </form>
-      )}
+              Delete item
+            </MenuItem>
+          </MoreMenu>
+        )}
+      </div>
     </div>
+  );
+}
+
+function MoreMenu({
+  children,
+  onClose,
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    function onDown(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      className="absolute right-0 top-full z-30 mt-1 w-48 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] py-1 shadow-lg"
+    >
+      {children}
+    </div>
+  );
+}
+
+function MenuItem({
+  children,
+  onClick,
+  disabled,
+  destructive,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      disabled={disabled}
+      className={`block w-full px-3 py-1.5 text-left text-sm hover:bg-[var(--surface-muted)] disabled:opacity-50 ${
+        destructive
+          ? "text-[var(--accent-rose-soft-fg)]"
+          : "text-[var(--text-primary)]"
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -200,7 +324,7 @@ function Field({
 }) {
   return (
     <label className="flex flex-col gap-1">
-      <span className="text-xs font-medium text-[var(--accent-amber-soft-fg)]">
+      <span className="text-[11px] font-medium text-[var(--text-secondary)]">
         {label}
       </span>
       {children}
@@ -208,6 +332,8 @@ function Field({
   );
 }
 
+// Kept exported for any external imports; no longer rendered on the detail
+// page (delete moved into the More menu next to ItemActions).
 export function DeleteItemButton({ id }: { id: string }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -3,23 +3,11 @@ import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
 import { userScope } from "@/lib/db/scoped";
 import { Card, StatusPill } from "@/components/ui";
-import { DeleteItemButton, ItemActions } from "./actions";
+import { ItemActions } from "./actions";
 import { ItemPhotos } from "./photos";
 
 function gbp(n: string | null) {
   return n == null ? "—" : `£${parseFloat(n).toFixed(2)}`;
-}
-
-function formatDateTime(d: Date | string | null) {
-  if (!d) return "—";
-  const date = typeof d === "string" ? new Date(d) : d;
-  return date.toLocaleString("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 function formatDate(d: Date | string | null) {
@@ -58,22 +46,22 @@ export default async function ItemDetail({
   const subtitleParts = [item.brand, item.category, item.size].filter(Boolean);
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <header className="space-y-2">
+    <div className="space-y-4">
+      {/* Header — compact, single row of meta + status */}
+      <header className="space-y-1">
         <Link
           href="/inventory"
           className="inline-flex items-center gap-1 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
         >
           <span aria-hidden>←</span> Inventory
         </Link>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="font-display text-xl font-semibold tracking-tight text-[var(--text-primary)] md:text-2xl">
               {item.name}
             </h1>
             {subtitleParts.length > 0 && (
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+              <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
                 {subtitleParts.join(" · ")}
               </p>
             )}
@@ -83,14 +71,14 @@ export default async function ItemDetail({
       </header>
 
       {/* Hero row: photos (left) + facts/actions (right) */}
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
         <Card>
           <ItemPhotos itemId={item.id} initialPhotos={item.photoUrls ?? []} />
         </Card>
 
-        <div className="space-y-4">
+        <div className="space-y-3">
           <Card>
-            <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
               <Row label="Cost" value={gbp(item.costPrice)} />
               <Row label="Listed" value={gbp(item.listedPrice)} />
               <Row label="Sold" value={gbp(item.soldPrice)} />
@@ -102,13 +90,10 @@ export default async function ItemDetail({
                     : "—"
                 }
               />
-              <Row label="Listed at" value={formatDateTime(item.listedAt)} />
-              <Row label="Sold at" value={formatDateTime(item.soldAt)} />
+              <Row label="Listed at" value={formatDate(item.listedAt)} />
+              <Row label="Sold at" value={formatDate(item.soldAt)} />
               {item.shippedAt && (
-                <Row
-                  label="Shipped at"
-                  value={formatDateTime(item.shippedAt)}
-                />
+                <Row label="Shipped at" value={formatDate(item.shippedAt)} />
               )}
             </dl>
           </Card>
@@ -122,14 +107,10 @@ export default async function ItemDetail({
               soldPrice={item.soldPrice}
             />
           </Card>
-
-          <div className="flex justify-end">
-            <DeleteItemButton id={item.id} />
-          </div>
         </div>
       </div>
 
-      {/* Description */}
+      {/* Description — below the fold */}
       {item.description && (
         <Card>
           <h2 className="text-sm font-semibold text-[var(--text-secondary)]">
@@ -141,7 +122,7 @@ export default async function ItemDetail({
         </Card>
       )}
 
-      {/* Transactions */}
+      {/* Transactions — below the fold */}
       <Card padded={false}>
         <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-5 py-4">
           <h2 className="text-sm font-semibold text-[var(--text-secondary)]">
@@ -220,7 +201,7 @@ export default async function ItemDetail({
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
+      <dt className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
         {label}
       </dt>
       <dd className="mt-0.5 text-sm font-medium text-[var(--text-primary)]">

--- a/src/app/(app)/inventory/[id]/photos.tsx
+++ b/src/app/(app)/inventory/[id]/photos.tsx
@@ -86,9 +86,9 @@ export function ItemPhotos({
   }
 
   return (
-    <section className="space-y-3">
+    <section className="space-y-2">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-medium text-[var(--text-secondary)]">
+        <h2 className="text-xs font-medium text-[var(--text-secondary)]">
           Photos
           {photos.length > 0 && (
             <span className="ml-1 text-[var(--text-muted)]">
@@ -116,19 +116,19 @@ export function ItemPhotos({
       )}
 
       {photos.length === 0 ? (
-        <div className="flex aspect-square w-full items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-[var(--border-subtle)] bg-[var(--surface-inset)] text-sm text-[var(--text-muted)]">
+        <div className="flex h-[340px] w-full items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-[var(--border-subtle)] bg-[var(--surface-inset)] text-sm text-[var(--text-muted)]">
           {canAdd
             ? "No photos yet — add up to 10 (resized to 1200px)."
             : "No photos."}
         </div>
       ) : (
         <>
-          <div className="relative aspect-square w-full overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
+          <div className="relative h-[340px] w-full overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={active}
               alt={`Photo ${activeIndex + 1}`}
-              className="h-full w-full object-cover"
+              className="h-full w-full object-contain"
             />
             <button
               type="button"
@@ -142,7 +142,7 @@ export function ItemPhotos({
           </div>
 
           {photos.length > 1 && (
-            <div className="grid grid-cols-5 gap-2">
+            <div className="flex gap-2 overflow-x-auto pb-1">
               {photos.map((src, i) => (
                 <button
                   key={i}
@@ -150,7 +150,7 @@ export function ItemPhotos({
                   onClick={() => setActiveIndex(i)}
                   aria-label={`Show photo ${i + 1}`}
                   aria-current={i === activeIndex}
-                  className={`relative aspect-square overflow-hidden rounded-[var(--radius-md)] border bg-[var(--surface-inset)] transition ${
+                  className={`relative h-14 w-14 flex-none overflow-hidden rounded-[var(--radius-md)] border bg-[var(--surface-inset)] transition ${
                     i === activeIndex
                       ? "border-[var(--brand)] ring-2 ring-[var(--brand)]/30"
                       : "border-[var(--border-subtle)] hover:border-[var(--border-default)]"


### PR DESCRIPTION
Closes #39

## Summary
- Hero photo capped at 340px tall (object-contain) and thumbnails moved to a horizontal strip below the hero — no more aspect-square hero eating the viewport.
- Header tightened (xl/2xl title, less vertical spacing, short dates) so breadcrumb + title + pill fit on one compact band.
- Right column narrowed to 340px with denser 2-col facts grid.
- Status-driven action zone collapses to one primary CTA. The secondary "Mark as sourced" demote action and Delete moved into a "More" disclosure menu, so they no longer contribute to above-the-fold height.
- Mark-as-sold form is now an absolutely-positioned popover anchored to the primary button — when expanded it overlays neighbouring content and does **not** grow the page. Click-outside / Escape to dismiss.
- Description and Transactions card sit deliberately below the fold.

## No-scroll verification
Eyeballed each of the four statuses at 1280x800:
- **sourced** — collapsed primary "Mark as listed" + More menu. Fits.
- **listed** — collapsed primary "Mark as sold" + More menu (Delete + Mark as sourced live there). Fits. Sell popover overlays facts when opened, no page growth.
- **sold** — primary "Mark as shipped" + More menu. Fits.
- **shipped** — no primary action; shows "No further actions" hint inline + More menu (Delete only). Fits.

## Constraints honoured
- No fees field anywhere (Vinted has no seller fees — AGENTS.md).
- No Turbopack toggling, no data-layer changes, scope limited to `src/app/(app)/inventory/[id]/**`.
- Existing design-system primitives only (Button, Card, StatusPill).

## Test plan
- [ ] Visit an item in each of the 4 statuses at 1280x800 — confirm no page scroll on first load.
- [ ] Click the primary CTA on a `listed` item — sell popover opens over the facts column, page does not scroll.
- [ ] Confirm sale — item flips to `sold`, transaction row appears below.
- [ ] Open More menu on each status — confirm Delete (and Mark as sourced for `listed`) work.
- [ ] Photos: upload, switch via thumb strip, remove — strip stays horizontal and scrolls if >5 photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)