### PR TITLE
Acquisition type (bought/own) + null-cost = 0 audit (#45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,7 @@ This app is Vinted-only and Vinted **does not charge sellers any fees** — no l
 - **Sample data** must NOT seed fee values.
 
 The `transactions.platformFees` column in the schema is retained as a dead, default-zero field — do not surface it, but don't drop it in a migration either (low value, migration risk). New code paths should ignore it.
+
+### Cost handling
+
+Items have an `acquisitionType` of `bought` or `own`. **`own` items always treat cost as 0** — the new-item form hides the cost field for them, and completeness checks do not flag missing cost. Anywhere cost is read for math, route through `coerceMoney()` from `src/lib/money.ts` so null and missing values become 0 cleanly. Reporting splits bought vs own (issue #46) — never blend them when showing a "profit margin" %.

--- a/drizzle/0006_short_chronomancer.sql
+++ b/drizzle/0006_short_chronomancer.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."acquisition_type" AS ENUM('bought', 'own');--> statement-breakpoint
+ALTER TABLE "items" ADD COLUMN "acquisition_type" "acquisition_type" DEFAULT 'bought' NOT NULL;--> statement-breakpoint
+-- Backfill: items with no real cost are treated as 'own'. New rows continue to
+-- default to 'bought'. See AGENTS.md → "Cost handling".
+UPDATE "items" SET "acquisition_type" = 'own' WHERE "cost_price" IS NULL OR "cost_price" = 0;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1092 @@
+{
+  "id": "d5ab8726-90d7-42e1-9228-a24a8b158d7f",
+  "prevId": "b8e235fe-ee62-4e79-9f15-80b4a7b177c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incurred_at": {
+          "name": "incurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_incurred_idx": {
+          "name": "expenses_user_incurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_category_idx": {
+          "name": "expenses_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_sample_idx": {
+          "name": "expenses_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_type": {
+          "name": "acquisition_type",
+          "type": "acquisition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bought'"
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_price": {
+          "name": "listed_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sourced'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'vinted'"
+        },
+        "photo_urls": {
+          "name": "photo_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinted_url": {
+          "name": "vinted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buyer_paid_shipping": {
+          "name": "buyer_paid_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_at": {
+          "name": "last_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relist_count": {
+          "name": "relist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_user_status_idx": {
+          "name": "items_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sample_idx": {
+          "name": "items_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_brand_idx": {
+          "name": "items_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_category_idx": {
+          "name": "items_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_created_idx": {
+          "name": "items_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_listed_idx": {
+          "name": "items_user_listed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sold_idx": {
+          "name": "items_user_sold_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sold_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_data": {
+      "name": "price_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_minor": {
+          "name": "price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_data_user_observed_idx": {
+          "name": "price_data_user_observed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_brand_idx": {
+          "name": "price_data_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_source_external_idx": {
+          "name": "price_data_user_source_external_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_stats": {
+      "name": "price_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_size": {
+          "name": "sample_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_minor": {
+          "name": "median_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p25_minor": {
+          "name": "p25_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p75_minor": {
+          "name": "p75_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_minor": {
+          "name": "mean_minor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_stats_user_bucket_idx": {
+          "name": "price_stats_user_bucket_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_price": {
+          "name": "gross_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_cost": {
+          "name": "shipping_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "platform_fees": {
+          "name": "platform_fees",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "profit": {
+          "name": "profit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_item_idx": {
+          "name": "transactions_user_item_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_completed_idx": {
+          "name": "transactions_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_sample_idx": {
+          "name": "transactions_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_item_id_items_id_fk": {
+          "name": "transactions_item_id_items_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_key_idx": {
+          "name": "user_settings_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.acquisition_type": {
+      "name": "acquisition_type",
+      "schema": "public",
+      "values": [
+        "bought",
+        "own"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777825482317,
       "tag": "0005_warm_forge",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777928975583,
+      "tag": "0006_short_chronomancer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/inventory/[id]/AcquisitionChip.tsx
+++ b/src/app/(app)/inventory/[id]/AcquisitionChip.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type AcquisitionType = "bought" | "own";
+
+const LABEL: Record<AcquisitionType, string> = {
+  bought: "Bought",
+  own: "Own",
+};
+
+/**
+ * Small chip rendered next to StatusPill on the item-detail page. Click to
+ * toggle between `bought` and `own`. Switching to `own` zeros the cost on
+ * the server; switching to `bought` clears it for re-entry. See AGENTS.md →
+ * "Cost handling".
+ */
+export function AcquisitionChip({
+  id,
+  initial,
+}: {
+  id: string;
+  initial: AcquisitionType;
+}) {
+  const router = useRouter();
+  const [type, setType] = useState<AcquisitionType>(initial);
+  const [busy, setBusy] = useState(false);
+
+  async function toggle() {
+    const next: AcquisitionType = type === "bought" ? "own" : "bought";
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/inventory/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ acquisitionType: next }),
+      });
+      if (res.ok) {
+        setType(next);
+        router.refresh();
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={busy}
+      title="Toggle acquisition type"
+      aria-label={`Acquisition type: ${LABEL[type]}. Click to change.`}
+      className="inline-flex items-center gap-1.5 rounded-full bg-[var(--surface-muted)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-secondary)] hover:bg-[var(--surface-inset)] hover:text-[var(--text-primary)] disabled:opacity-50"
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full bg-[var(--text-muted)]"
+        aria-hidden
+      />
+      {LABEL[type]}
+    </button>
+  );
+}

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -5,6 +5,7 @@ import { userScope } from "@/lib/db/scoped";
 import { Card, StatusPill } from "@/components/ui";
 import { ItemActions } from "./actions";
 import { ItemPhotos } from "./photos";
+import { AcquisitionChip } from "./AcquisitionChip";
 
 function gbp(n: string | null) {
   return n == null ? "—" : `£${parseFloat(n).toFixed(2)}`;
@@ -66,7 +67,10 @@ export default async function ItemDetail({
               </p>
             )}
           </div>
-          <StatusPill status={item.status} size="md" />
+          <div className="flex items-center gap-2">
+            <StatusPill status={item.status} size="md" />
+            <AcquisitionChip id={item.id} initial={item.acquisitionType} />
+          </div>
         </div>
       </header>
 

--- a/src/app/(app)/inventory/new/form.tsx
+++ b/src/app/(app)/inventory/new/form.tsx
@@ -3,10 +3,14 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+type AcquisitionType = "bought" | "own";
+
 export function NewItemForm() {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [acquisitionType, setAcquisitionType] =
+    useState<AcquisitionType>("bought");
   const [form, setForm] = useState({
     name: "",
     brand: "",
@@ -29,12 +33,20 @@ export function NewItemForm() {
     setBusy(true);
     setError(null);
     try {
+      // 'own' items always have cost = 0 (cleaner than null going forward).
+      const costPrice =
+        acquisitionType === "own"
+          ? "0"
+          : form.costPrice === ""
+            ? null
+            : form.costPrice;
       const res = await fetch("/api/inventory", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           ...form,
-          costPrice: form.costPrice || null,
+          acquisitionType,
+          costPrice,
           listedPrice: form.listedPrice || null,
           vintedUrl: form.vintedUrl || null,
           brand: form.brand || null,
@@ -56,6 +68,47 @@ export function NewItemForm() {
 
   return (
     <form onSubmit={submit} className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="md:col-span-2">
+        <span className="text-xs uppercase text-gray-500">
+          Where did this come from?
+        </span>
+        <div
+          role="radiogroup"
+          aria-label="Where did this come from?"
+          className="mt-1 inline-flex rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] p-1"
+        >
+          {(
+            [
+              { value: "bought", label: "Bought" },
+              { value: "own", label: "Own" },
+            ] as const
+          ).map((opt) => {
+            const isActive = acquisitionType === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                onClick={() => setAcquisitionType(opt.value)}
+                className={`inline-flex items-center rounded-[var(--radius-md)] px-4 py-1.5 text-xs font-medium transition-colors ${
+                  isActive
+                    ? "bg-[var(--brand)] text-white shadow-[var(--elev-1)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--surface-card)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-1 text-[11px] text-gray-500">
+          {acquisitionType === "own"
+            ? "Already yours — we treat the cost as £0."
+            : "Sourced for resale — record what you paid."}
+        </p>
+      </div>
+
       <Field label="Name *" full>
         <input
           required
@@ -98,15 +151,17 @@ export function NewItemForm() {
           ))}
         </select>
       </Field>
-      <Field label="Cost price (£)">
-        <input
-          type="number"
-          step="0.01"
-          value={form.costPrice}
-          onChange={(e) => set("costPrice", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
-        />
-      </Field>
+      {acquisitionType === "bought" && (
+        <Field label="Cost price (£)">
+          <input
+            type="number"
+            step="0.01"
+            value={form.costPrice}
+            onChange={(e) => set("costPrice", e.target.value)}
+            className="w-full rounded-md border px-3 py-2 text-sm"
+          />
+        </Field>
+      )}
       <Field label="Listed price (£)">
         <input
           type="number"

--- a/src/app/(app)/inventory/status-actions.ts
+++ b/src/app/(app)/inventory/status-actions.ts
@@ -3,6 +3,7 @@
 import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 import { userScope } from "@/lib/db/scoped";
+import { coerceMoney } from "@/lib/money";
 
 type Status = "sourced" | "listed" | "sold" | "shipped";
 
@@ -51,9 +52,9 @@ export async function markItemSoldAction(
 
   const [updated] = await scope.updateItem(id, updates);
 
-  const cost = updated.costPrice ?? "0";
+  const cost = coerceMoney(updated.costPrice);
   const profit = (
-    Number(soldPrice) - Number(cost) - Number(shipping)
+    coerceMoney(soldPrice) - cost - coerceMoney(shipping)
   ).toFixed(2);
 
   await scope.insertTransaction({

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
+import { coerceMoney } from "@/lib/money";
 
 export const runtime = "nodejs";
 
@@ -35,6 +36,7 @@ const PatchSchema = z.object({
   photoUrls: z.array(z.string()).nullish(),
   thumbnailUrl: z.string().nullish(),
   status: z.enum(["sourced", "listed", "sold", "shipped"]).optional(),
+  acquisitionType: z.enum(["bought", "own"]).optional(),
   shippingCost: numStr, // for the auto-created sell tx
 });
 
@@ -81,6 +83,20 @@ export async function PATCH(
     if (v !== undefined) updates[k] = v;
   }
 
+  // Acquisition-type semantics:
+  //   • Switching to 'own' zeros the cost.
+  //   • Switching to 'bought' clears cost so the user can re-enter it
+  //     (unless they passed a costPrice in the same request).
+  if (data.acquisitionType === "own") {
+    updates.costPrice = "0";
+  } else if (
+    data.acquisitionType === "bought" &&
+    existing.acquisitionType !== "bought" &&
+    data.costPrice === undefined
+  ) {
+    updates.costPrice = null;
+  }
+
   // Status transitions stamp the corresponding timestamp.
   if (data.status && data.status !== existing.status) {
     if (data.status === "listed" && !existing.listedAt) updates.listedAt = now;
@@ -94,9 +110,8 @@ export async function PATCH(
   if (data.status === "sold" && existing.status !== "sold") {
     const gross = data.soldPrice ?? updated.soldPrice ?? updated.listedPrice ?? "0";
     const shipping = data.shippingCost ?? "0";
-    const cost = updated.costPrice ?? "0";
     const profit = (
-      Number(gross) - Number(cost) - Number(shipping)
+      coerceMoney(gross) - coerceMoney(updated.costPrice) - coerceMoney(shipping)
     ).toFixed(2);
 
     await scope.insertTransaction({

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -65,6 +65,7 @@ const CreateSchema = z.object({
   photoUrls: z.array(z.string()).nullish(),
   thumbnailUrl: z.string().nullish(),
   status: z.enum(["sourced", "listed", "sold", "shipped"]).optional(),
+  acquisitionType: z.enum(["bought", "own"]).optional(),
 });
 
 export async function POST(req: NextRequest) {
@@ -107,6 +108,10 @@ export async function POST(req: NextRequest) {
   }
 
   const status = data.status ?? "sourced";
+  const acquisitionType = data.acquisitionType ?? "bought";
+  // 'own' items always have cost = 0; ignore any incoming non-zero cost.
+  const costPrice =
+    acquisitionType === "own" ? "0" : (data.costPrice ?? null);
   const now = new Date();
   const [item] = await scope.insertItem({
     name: data.name,
@@ -114,7 +119,8 @@ export async function POST(req: NextRequest) {
     category: data.category ?? null,
     condition: data.condition ?? null,
     size: data.size ?? null,
-    costPrice: data.costPrice ?? null,
+    acquisitionType,
+    costPrice,
     listedPrice: data.listedPrice ?? null,
     description: data.description ?? null,
     sourceType: data.sourceType ?? null,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,5 @@
 import {
+  pgEnum,
   pgTable,
   text,
   integer,
@@ -10,6 +11,13 @@ import {
   uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+
+/**
+ * Acquisition type — `bought` (sourced for resale, has a real cost) vs
+ * `own` (already owned, cost is genuinely 0). See AGENTS.md → "Cost handling".
+ */
+export const acquisitionTypeEnum = pgEnum("acquisition_type", ["bought", "own"]);
+export type AcquisitionType = (typeof acquisitionTypeEnum.enumValues)[number];
 
 /**
  * Tenancy invariant: every row belongs to one Clerk user.
@@ -85,6 +93,9 @@ export const items = pgTable(
     category: text("category"),
     condition: text("condition"), // new | like_new | good | fair
     size: text("size"),
+    acquisitionType: acquisitionTypeEnum("acquisition_type")
+      .notNull()
+      .default("bought"),
     costPrice: numeric("cost_price", { precision: 10, scale: 2 }),
     listedPrice: numeric("listed_price", { precision: 10, scale: 2 }),
     soldPrice: numeric("sold_price", { precision: 10, scale: 2 }),

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
+import { coerceMoney } from "@/lib/money";
 
 export const MIN_GROUP_SIZE = 2;
 
@@ -31,7 +32,7 @@ export interface GroupStat {
 
 export type BestsellersReport = Awaited<ReturnType<typeof computeBestsellers>>;
 
-const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+const num = coerceMoney;
 
 function median(values: number[]): number {
   if (values.length === 0) return 0;

--- a/src/lib/analytics/health.ts
+++ b/src/lib/analytics/health.ts
@@ -4,8 +4,9 @@ import { items } from "@/db/schema";
 import { computeCadence, type CadenceResult } from "@/lib/inventory/cadence";
 import { scoreItem, summarise, type CompletenessSummary } from "@/lib/inventory/completeness";
 import { getTargets } from "@/lib/settings";
+import { coerceMoney } from "@/lib/money";
 
-const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+const num = coerceMoney;
 
 export type HealthReport = Awaited<ReturnType<typeof computeHealth>>;
 

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -2,8 +2,9 @@ import { and, eq, gte, lte } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, expenses } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
+import { coerceMoney } from "@/lib/money";
 
-const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+const num = coerceMoney;
 
 export type ProfitSeriesPoint = {
   /** ISO yyyy-mm-dd */

--- a/src/lib/analytics/profit.ts
+++ b/src/lib/analytics/profit.ts
@@ -2,8 +2,9 @@ import { and, eq, gte, lte, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, expenses } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
+import { coerceMoney } from "@/lib/money";
 
-const num = (s: string | null | undefined) => (s ? parseFloat(s) : 0);
+const num = coerceMoney;
 const round = (n: number) => Math.round(n * 100) / 100;
 
 export type ProfitReport = Awaited<ReturnType<typeof computeProfit>>;

--- a/src/lib/inventory/completeness.ts
+++ b/src/lib/inventory/completeness.ts
@@ -1,6 +1,12 @@
 // Listing completeness score (0-100). Weights sum to 100; missing fields are
 // penalised. `condition` is intentionally omitted (UX choice — see legacy notes);
 // `vintedUrl` takes its slot.
+//
+// Cost is NOT a completeness field. Per AGENTS.md → "Cost handling", items
+// with `acquisitionType === "own"` always have cost = 0; treating cost as
+// "missing" for them would penalise a perfectly valid listing. The current
+// weights ignore cost entirely so own and bought items are scored on the
+// same fields, which is what we want.
 
 export const WEIGHTS = {
   brand: 20,

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,14 @@
+/**
+ * Coerce any money-shaped value (string, number, null, undefined) into a
+ * finite number. `null` and `undefined` — and any non-numeric string —
+ * collapse to 0. This is the single source of truth for "null cost = 0"
+ * across the app: route every cost/price read through here so analytics,
+ * profit math, and completeness all agree.
+ *
+ * See AGENTS.md → "Cost handling" for the design rule.
+ */
+export function coerceMoney(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  const n = typeof value === "string" ? Number(value) : value;
+  return Number.isFinite(n) ? n : 0;
+}


### PR DESCRIPTION
Closes #45

## Summary

- Add `acquisitionType` enum (`bought | own`) to items, NOT NULL, default `bought`. Migration backfills `own` for any row whose `cost_price` is NULL or 0.
- New-item form leads with a "Where did this come from?" segmented control. "Bought" shows the existing Cost input; "Own" hides it and persists `costPrice = "0"`.
- Item detail renders a small "Bought" / "Own" chip next to the StatusPill. Click toggles via PATCH — switching to `own` zeros cost; switching to `bought` clears cost for re-entry.
- New `src/lib/money.ts` exports `coerceMoney()`. All cost/price reads in analytics + status actions route through it so null/missing values become 0 cleanly.
- `completeness.ts` documents that cost is intentionally NOT a tracked field — own items are scored on the same fields as bought items.
- AGENTS.md gains a new **"Cost handling"** subsection under Design constraints.

## Audited cost-read sites

- `src/lib/analytics/profit.ts`
- `src/lib/analytics/profit-series.ts`
- `src/lib/analytics/bestsellers.ts`
- `src/lib/analytics/health.ts`
- `src/app/(app)/inventory/status-actions.ts` (`markItemSoldAction` profit calc)
- `src/app/api/inventory/[id]/route.ts` (auto-created sell tx profit calc)

The dashboard top-profit table and health stale-£/dead-stock-value flow through `computeProfit` and `computeHealth` and so are covered transitively.

## Migration

`drizzle/0006_short_chronomancer.sql` is deterministic — DDL plus backfill in the same file:

```sql
CREATE TYPE "public"."acquisition_type" AS ENUM('bought', 'own');
ALTER TABLE "items" ADD COLUMN "acquisition_type" "acquisition_type" DEFAULT 'bought' NOT NULL;
UPDATE "items" SET "acquisition_type" = 'own' WHERE "cost_price" IS NULL OR "cost_price" = 0;
```

`scripts/tenancy-check.mjs` is unchanged — this is a column add on an existing per-user table, not a new domain table.

## AGENTS.md rule added

New "Cost handling" subsection: own items always treat cost as 0; route every cost read through `coerceMoney()`; reporting splits bought vs own (issue #46).

## Test plan

- [ ] New-item form: toggling between Bought and Own shows/hides Cost.
- [ ] Saving an Own item persists `acquisitionType="own"` and `costPrice="0"`.
- [ ] Detail-page chip toggles via PATCH; Own zeros cost, Bought clears it.
- [ ] Profit/Health/Bestsellers don't blow up on items with null cost.
- [ ] `pnpm exec tsc --noEmit` clean; `pnpm build` succeeds (postbuild migration applies cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)