### PR TITLE
Reporting: split bought vs own across /profit /bestsellers /dashboard (#46)

### DIFF
--- a/src/app/(app)/bestsellers/page.tsx
+++ b/src/app/(app)/bestsellers/page.tsx
@@ -7,6 +7,7 @@ import {
   type GroupStat,
   type ItemStat,
 } from "@/lib/analytics/bestsellers";
+import type { AcquisitionType } from "@/db/schema";
 import { resolveDateRange } from "@/lib/date-range";
 import {
   Card,
@@ -72,6 +73,13 @@ const SORTS: { value: SortKey; label: string }[] = [
   { value: "margin", label: "Margin" },
 ];
 
+type TypeFilter = "all" | "bought" | "own";
+const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "bought", label: "Bought" },
+  { value: "own", label: "Own" },
+];
+
 function sortGroups(groups: GroupStat[], sort: SortKey): GroupStat[] {
   const copy = [...groups];
   if (sort === "fastest") return copy.sort((a, b) => a.medianDaysToSell - b.medianDaysToSell);
@@ -79,30 +87,48 @@ function sortGroups(groups: GroupStat[], sort: SortKey): GroupStat[] {
   return copy.sort((a, b) => b.medianMarginPct - a.medianMarginPct);
 }
 
-function buildHref(params: { preset?: string; dim: Dimension; sort: SortKey }): string {
+function buildHref(params: {
+  preset?: string;
+  dim: Dimension;
+  sort: SortKey;
+  type: TypeFilter;
+}): string {
   const sp = new URLSearchParams({ dim: params.dim, sort: params.sort });
   if (params.preset) sp.set("preset", params.preset);
+  if (params.type !== "all") sp.set("type", params.type);
   return `/bestsellers?${sp.toString()}`;
 }
 
 export default async function BestsellersPage({
   searchParams,
 }: {
-  searchParams: Promise<{ preset?: string; dim?: string; sort?: string }>;
+  searchParams: Promise<{ preset?: string; dim?: string; sort?: string; type?: string }>;
 }) {
   const { userId } = await auth();
   if (!userId) redirect("/");
 
-  const { preset = "", dim = "category", sort = "fastest" } = await searchParams;
+  const {
+    preset = "",
+    dim = "category",
+    sort = "fastest",
+    type = "all",
+  } = await searchParams;
   const dimension: Dimension = (
     DIMENSIONS.map((d) => d.value).includes(dim as Dimension) ? dim : "category"
   ) as Dimension;
   const sortKey: SortKey = (
     SORTS.map((s) => s.value).includes(sort as SortKey) ? sort : "fastest"
   ) as SortKey;
+  const typeFilter: TypeFilter = (
+    TYPE_OPTIONS.map((o) => o.value).includes(type as TypeFilter)
+      ? (type as TypeFilter)
+      : "all"
+  );
+  const acquisitionFilter: AcquisitionType | undefined =
+    typeFilter === "all" ? undefined : (typeFilter as AcquisitionType);
 
   const range = resolveDateRange(preset || null, null, null);
-  const data = await computeBestsellers(userId, range);
+  const data = await computeBestsellers(userId, range, acquisitionFilter);
   const groups = sortGroups(data.groups[dimension], sortKey);
   const hasEnough = data.overall.totalSold >= data.minGroupSize;
 
@@ -112,9 +138,19 @@ export default async function BestsellersPage({
         title="Best sellers"
         subtitle="What's flying out the door — time-to-sell grouped by product attributes."
         actions={
+          <div className="flex items-center gap-3">
+            <SegmentedControl
+              options={TYPE_OPTIONS}
+              active={typeFilter}
+              tone="brand"
+              hrefFor={(v) =>
+                buildHref({ preset, dim: dimension, sort: sortKey, type: v })
+              }
+            />
           <form className="flex items-center gap-2 text-sm">
             <input type="hidden" name="dim" value={dimension} />
             <input type="hidden" name="sort" value={sortKey} />
+            <input type="hidden" name="type" value={typeFilter} />
             <select
               name="preset"
               defaultValue={preset}
@@ -134,6 +170,7 @@ export default async function BestsellersPage({
               Apply
             </button>
           </form>
+          </div>
         }
       />
 
@@ -162,17 +199,31 @@ export default async function BestsellersPage({
           label="Median profit"
           value={data.overall.totalSold ? gbp(data.overall.medianProfit) : "—"}
         />
-        <Tile
-          tone="violet"
-          icon={<span aria-hidden>%</span>}
-          label="Median margin"
-          value={data.overall.totalSold ? pct(data.overall.medianMarginPct) : "—"}
-          sub={
-            data.overall.totalSold
-              ? `${gbp0(data.overall.totalRevenue)} revenue`
-              : undefined
-          }
-        />
+        {typeFilter === "own" ? (
+          <Tile
+            tone="violet"
+            icon={<span aria-hidden>£</span>}
+            label="Mean sold for"
+            value={data.overall.totalSold ? gbp(data.overall.meanSoldPrice) : "—"}
+            sub={
+              data.overall.totalSold
+                ? `${gbp0(data.overall.totalRevenue)} revenue`
+                : undefined
+            }
+          />
+        ) : (
+          <Tile
+            tone="violet"
+            icon={<span aria-hidden>%</span>}
+            label="Median margin"
+            value={data.overall.totalSold ? pct(data.overall.medianMarginPct) : "—"}
+            sub={
+              data.overall.totalSold
+                ? `${gbp0(data.overall.totalRevenue)} revenue`
+                : undefined
+            }
+          />
+        )}
       </section>
 
       {!hasEnough ? (
@@ -202,19 +253,23 @@ export default async function BestsellersPage({
                 options={DIMENSIONS}
                 active={dimension}
                 tone="brand"
-                hrefFor={(v) => buildHref({ preset, dim: v, sort: sortKey })}
+                hrefFor={(v) => buildHref({ preset, dim: v, sort: sortKey, type: typeFilter })}
               />
               <SegmentedControl
                 label="Sort"
                 options={SORTS}
                 active={sortKey}
                 tone="emerald"
-                hrefFor={(v) => buildHref({ preset, dim: dimension, sort: v })}
+                hrefFor={(v) => buildHref({ preset, dim: dimension, sort: v, type: typeFilter })}
               />
             </div>
 
             <div className="mt-5">
-              <GroupTable dimension={dimension} groups={groups} />
+              <GroupTable
+                dimension={dimension}
+                groups={groups}
+                hideMargin={typeFilter === "own"}
+              />
             </div>
           </Card>
 
@@ -274,9 +329,11 @@ const MARGIN_TONE: Record<"good" | "watch" | "bad", { bar: string; pill: string 
 function GroupTable({
   dimension,
   groups,
+  hideMargin,
 }: {
   dimension: Dimension;
   groups: GroupStat[];
+  hideMargin?: boolean;
 }) {
   if (groups.length === 0) {
     return (
@@ -296,7 +353,11 @@ function GroupTable({
             <th className="py-2 pr-3 text-right font-medium">Median days</th>
             <th className="py-2 pr-3 text-right font-medium">Range</th>
             <th className="py-2 pr-3 text-right font-medium">Median profit</th>
-            <th className="py-2 pr-3 font-medium">Margin</th>
+            {hideMargin ? (
+              <th className="py-2 pr-3 text-right font-medium">Mean sold for</th>
+            ) : (
+              <th className="py-2 pr-3 font-medium">Margin</th>
+            )}
             <th className="py-2 pr-3 text-right font-medium">Revenue</th>
           </tr>
         </thead>
@@ -325,21 +386,27 @@ function GroupTable({
                 <td className="py-3 pr-3 text-right tabular-nums text-[var(--text-primary)]">
                   {gbp(g.medianProfit)}
                 </td>
-                <td className="py-3 pr-3">
-                  <div className="flex items-center gap-2">
-                    <div className="h-1.5 w-20 overflow-hidden rounded-full bg-[var(--surface-inset)]">
-                      <div
-                        className={`h-full rounded-full ${tone.bar}`}
-                        style={{ width: `${barWidth}%` }}
-                      />
+                {hideMargin ? (
+                  <td className="py-3 pr-3 text-right tabular-nums text-[var(--text-primary)]">
+                    {gbp(g.meanSoldPrice)}
+                  </td>
+                ) : (
+                  <td className="py-3 pr-3">
+                    <div className="flex items-center gap-2">
+                      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-[var(--surface-inset)]">
+                        <div
+                          className={`h-full rounded-full ${tone.bar}`}
+                          style={{ width: `${barWidth}%` }}
+                        />
+                      </div>
+                      <span
+                        className={`rounded-[var(--radius-sm)] px-1.5 py-0.5 text-xs font-medium tabular-nums ${tone.pill}`}
+                      >
+                        {pct(g.medianMarginPct)}
+                      </span>
                     </div>
-                    <span
-                      className={`rounded-[var(--radius-sm)] px-1.5 py-0.5 text-xs font-medium tabular-nums ${tone.pill}`}
-                    >
-                      {pct(g.medianMarginPct)}
-                    </span>
-                  </div>
-                </td>
+                  </td>
+                )}
                 <td className="py-3 pr-3 text-right tabular-nums text-[var(--text-secondary)]">
                   {gbp(g.totalRevenue)}
                 </td>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -186,8 +186,18 @@ export default async function DashboardPage() {
                               <span className="m-auto text-[9px] uppercase text-[var(--text-muted)]">no img</span>
                             )}
                           </span>
-                          <span className="font-medium text-[var(--text-primary)] hover:underline">
-                            {p.name}
+                          <span className="flex items-center gap-2">
+                            <span className="font-medium text-[var(--text-primary)] hover:underline">
+                              {p.name}
+                            </span>
+                            {p.acquisitionType === "own" && (
+                              <span
+                                className="inline-flex items-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]"
+                                title="From your own goods"
+                              >
+                                Own
+                              </span>
+                            )}
                           </span>
                         </Link>
                       </td>

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -11,10 +11,12 @@ import {
   Card,
   CardHeader,
   PageHeader,
+  SegmentedControl,
   Tile,
 } from "@/components/ui";
 import { CostCompositionChart, RevenueVsCostsChart } from "./charts";
 import type { CostSlice } from "./charts";
+import type { AcquisitionType } from "@/db/schema";
 
 const PRESETS = [
   { value: "this_month", label: "This month" },
@@ -39,21 +41,44 @@ function formatRangeSubtitle(from: Date | null, to: Date | null) {
   return "";
 }
 
+type TypeFilter = "all" | "bought" | "own";
+const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "bought", label: "Bought" },
+  { value: "own", label: "Own" },
+];
+
+function buildProfitHref(preset: string, type: TypeFilter): string {
+  const sp = new URLSearchParams();
+  if (preset && preset !== "this_month") sp.set("preset", preset);
+  if (type !== "all") sp.set("type", type);
+  const qs = sp.toString();
+  return qs ? `/profit?${qs}` : "/profit";
+}
+
 export default async function ProfitPage({
   searchParams,
 }: {
-  searchParams: Promise<{ preset?: string }>;
+  searchParams: Promise<{ preset?: string; type?: string }>;
 }) {
   const { userId } = await auth();
   if (!userId) redirect("/");
 
-  const { preset = "this_month" } = await searchParams;
+  const { preset = "this_month", type = "all" } = await searchParams;
   const presetKey = preset === "all" ? "" : preset;
   const range = resolveDateRange(presetKey || null, null, null);
 
+  const typeFilter: TypeFilter = (
+    TYPE_OPTIONS.map((o) => o.value).includes(type as TypeFilter)
+      ? (type as TypeFilter)
+      : "all"
+  );
+  const acquisitionFilter: AcquisitionType | undefined =
+    typeFilter === "all" ? undefined : (typeFilter as AcquisitionType);
+
   const [r, series, itemCount] = await Promise.all([
-    computeProfit(userId, range),
-    computeProfitSeries(userId, range),
+    computeProfit(userId, range, acquisitionFilter),
+    computeProfitSeries(userId, range, acquisitionFilter),
     userScope(userId).countItems(),
   ]);
 
@@ -64,11 +89,32 @@ export default async function ProfitPage({
   const itemIds = r.itemProfits.map((p) => p.id);
   const thumbMap = await userScope(userId).getItemHasThumbnailMap(itemIds);
 
-  const costSlices: CostSlice[] = [
+  // Wardrobe (own) revenue context. Only meaningful in "all" mode and only when
+  // both bought and own contributed.
+  const ownRev = r.byAcquisition.own.revenue;
+  const ownCount = r.byAcquisition.own.count;
+  const boughtRev = r.byAcquisition.bought.revenue;
+  const showWardrobeContext =
+    typeFilter === "all" && ownRev > 0 && boughtRev > 0;
+
+  const baseCostSlices: CostSlice[] = [
     { name: "Cost of goods", value: s.cost, color: "var(--brand)" },
     { name: "Shipping", value: s.shipping, color: "var(--accent-amber)" },
     { name: "Other expenses", value: s.totalExpenses, color: "var(--accent-rose)" },
-  ].filter((s) => s.value > 0);
+  ].filter((slice) => slice.value > 0);
+  const costSlices: CostSlice[] = showWardrobeContext
+    ? [
+        ...baseCostSlices,
+        // Quiet "wardrobe revenue" annotation — surfaces own-goods contribution
+        // alongside the cost composition. Muted slate to keep brand teal on
+        // bought-revenue elsewhere.
+        {
+          name: "Wardrobe revenue",
+          value: ownRev,
+          color: "var(--text-muted)",
+        },
+      ]
+    : baseCostSlices;
   const totalCosts = s.cost + s.shipping + s.totalExpenses;
 
   return (
@@ -77,25 +123,34 @@ export default async function ProfitPage({
         title="Profit"
         subtitle={formatRangeSubtitle(range.from, range.to)}
         actions={
-          <form className="flex items-center gap-2 text-sm">
-            <select
-              name="preset"
-              defaultValue={preset}
-              className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm text-[var(--text-primary)]"
-            >
-              {PRESETS.map((p) => (
-                <option key={p.value} value={p.value}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
-            <button
-              type="submit"
-              className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm font-medium hover:bg-[var(--surface-muted)]"
-            >
-              Apply
-            </button>
-          </form>
+          <div className="flex items-center gap-3">
+            <SegmentedControl
+              options={TYPE_OPTIONS}
+              active={typeFilter}
+              tone="brand"
+              hrefFor={(v) => buildProfitHref(preset, v)}
+            />
+            <form className="flex items-center gap-2 text-sm">
+              <input type="hidden" name="type" value={typeFilter} />
+              <select
+                name="preset"
+                defaultValue={preset}
+                className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm text-[var(--text-primary)]"
+              >
+                {PRESETS.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm font-medium hover:bg-[var(--surface-muted)]"
+              >
+                Apply
+              </button>
+            </form>
+          </div>
         }
       />
 
@@ -236,6 +291,12 @@ export default async function ProfitPage({
             <SummaryRow label="Shipping" value={gbp(s.shipping)} />
             <SummaryRow label="Other expenses" value={gbp(s.totalExpenses)} />
           </dl>
+          {typeFilter === "all" && ownRev > 0 && (
+            <p className="mt-4 text-xs text-[var(--text-muted)]">
+              Of which {gbp(ownRev)} ({ownCount}{" "}
+              {ownCount === 1 ? "item" : "items"}) was from your own goods.
+            </p>
+          )}
         </Card>
       </section>
 

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@/db/client";
-import { items, transactions } from "@/db/schema";
+import { items, transactions, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
 
@@ -25,6 +25,7 @@ export interface GroupStat {
   medianDaysToSell: number;
   medianProfit: number;
   medianMarginPct: number;
+  meanSoldPrice: number;
   totalRevenue: number;
   fastestDays: number;
   slowestDays: number;
@@ -43,9 +44,18 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-export async function computeBestsellers(userId: string, range: DateRange) {
+export async function computeBestsellers(
+  userId: string,
+  range: DateRange,
+  acquisitionType?: AcquisitionType,
+) {
   // Pull sold + shipped items in the user's scope; we filter by soldAt range
   // in JS so the schema's soldAt nullable case stays explicit.
+  const conds = [
+    eq(items.userId, userId),
+    or(eq(items.status, "sold"), eq(items.status, "shipped"))!,
+  ];
+  if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
   const rows = await db
     .select({
       id: items.id,
@@ -61,12 +71,7 @@ export async function computeBestsellers(userId: string, range: DateRange) {
       soldAt: items.soldAt,
     })
     .from(items)
-    .where(
-      and(
-        eq(items.userId, userId),
-        or(eq(items.status, "sold"), eq(items.status, "shipped"))!,
-      ),
-    );
+    .where(and(...conds));
 
   const inRange = rows.filter((r) => {
     if (!r.listedAt || !r.soldAt) return false;
@@ -138,13 +143,15 @@ export async function computeBestsellers(userId: string, range: DateRange) {
     for (const [k, list] of buckets) {
       if (list.length < MIN_GROUP_SIZE) continue;
       const days = list.map((b) => b.daysToSell);
+      const totalRev = list.reduce((s, b) => s + b.soldPrice, 0);
       out.push({
         key: k,
         count: list.length,
         medianDaysToSell: median(days),
         medianProfit: median(list.map((b) => b.netProfit)),
         medianMarginPct: median(list.map((b) => b.marginPct)),
-        totalRevenue: list.reduce((s, b) => s + b.soldPrice, 0),
+        meanSoldPrice: list.length ? totalRev / list.length : 0,
+        totalRevenue: totalRev,
         fastestDays: Math.min(...days),
         slowestDays: Math.max(...days),
       });
@@ -160,15 +167,17 @@ export async function computeBestsellers(userId: string, range: DateRange) {
     size: buildGroups(dimensionKey.size),
   };
 
+  const overallTotalRev = itemStats.reduce((s, b) => s + b.soldPrice, 0);
   const overall = {
     totalSold: itemStats.length,
     medianDaysToSell: median(itemStats.map((s) => s.daysToSell)),
     medianProfit: median(itemStats.map((s) => s.netProfit)),
     medianMarginPct: median(itemStats.map((s) => s.marginPct)),
+    meanSoldPrice: itemStats.length ? overallTotalRev / itemStats.length : 0,
     fastestDays: itemStats.length
       ? Math.min(...itemStats.map((s) => s.daysToSell))
       : 0,
-    totalRevenue: itemStats.reduce((s, b) => s + b.soldPrice, 0),
+    totalRevenue: overallTotalRev,
   };
 
   const topFastest = [...itemStats]

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, lte } from "drizzle-orm";
 import { db } from "@/db/client";
-import { items, transactions, expenses } from "@/db/schema";
+import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
 
@@ -36,7 +36,10 @@ function startOfDay(d: Date) {
 export async function computeProfitSeries(
   userId: string,
   range: DateRange,
+  acquisitionType?: AcquisitionType,
 ): Promise<ProfitSeriesPoint[]> {
+  const conds = [eq(items.userId, userId)];
+  if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
   const sold = await db
     .select({
       id: items.id,
@@ -46,7 +49,7 @@ export async function computeProfitSeries(
       status: items.status,
     })
     .from(items)
-    .where(eq(items.userId, userId));
+    .where(and(...conds));
 
   // Clamp range
   const soldDates = sold

--- a/src/lib/analytics/profit.ts
+++ b/src/lib/analytics/profit.ts
@@ -1,6 +1,6 @@
 import { and, eq, gte, lte, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { items, transactions, expenses } from "@/db/schema";
+import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
 
@@ -13,8 +13,17 @@ export type ProfitReport = Awaited<ReturnType<typeof computeProfit>>;
  * User-scoped profit aggregation. Mirrors the original profit route's headline
  * shape — summary, stock, comparisons, breakdowns — minus targets and the
  * inventory-health buckets (those land alongside user_settings/daily-plan).
+ *
+ * `acquisitionType` (optional) scopes every aggregate to bought-only or own-only
+ * items. When omitted, both contribute. See issue #46.
  */
-export async function computeProfit(userId: string, range: DateRange) {
+export async function computeProfit(
+  userId: string,
+  range: DateRange,
+  acquisitionType?: AcquisitionType,
+) {
+  const conds = [eq(items.userId, userId)];
+  if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
   const allItems = await db
     .select({
       id: items.id,
@@ -28,9 +37,10 @@ export async function computeProfit(userId: string, range: DateRange) {
       soldAt: items.soldAt,
       listedAt: items.listedAt,
       sourceType: items.sourceType,
+      acquisitionType: items.acquisitionType,
     })
     .from(items)
-    .where(eq(items.userId, userId));
+    .where(and(...conds));
 
   const hasFilter = range.from != null || range.to != null;
   const sold = allItems.filter((i) => {
@@ -62,6 +72,13 @@ export async function computeProfit(userId: string, range: DateRange) {
   let cost = 0;
   let shipping = 0;
 
+  // Track per-acquisition-type splits so /profit can show a "wardrobe revenue"
+  // slice / footnote when both contributed in the period.
+  let boughtRevenue = 0;
+  let boughtCount = 0;
+  let ownRevenue = 0;
+  let ownCount = 0;
+
   const byCategory = new Map<string, { revenue: number; profit: number; count: number }>();
   const bySource = new Map<string, { revenue: number; profit: number; count: number }>();
   const byMonth = new Map<string, { revenue: number; profit: number; count: number }>();
@@ -73,6 +90,7 @@ export async function computeProfit(userId: string, range: DateRange) {
     cost: number;
     netProfit: number;
     soldAt: string | null;
+    acquisitionType: AcquisitionType;
   }> = [];
 
   for (const it of sold) {
@@ -85,6 +103,14 @@ export async function computeProfit(userId: string, range: DateRange) {
     revenue += s;
     cost += c;
     shipping += sh;
+
+    if (it.acquisitionType === "own") {
+      ownRevenue += s;
+      ownCount += 1;
+    } else {
+      boughtRevenue += s;
+      boughtCount += 1;
+    }
 
     const cat = it.category || "uncategorised";
     const src = it.sourceType || "unknown";
@@ -109,6 +135,7 @@ export async function computeProfit(userId: string, range: DateRange) {
       cost: c,
       netProfit: net,
       soldAt: it.soldAt?.toISOString() ?? null,
+      acquisitionType: it.acquisitionType,
     });
   }
 
@@ -158,6 +185,10 @@ export async function computeProfit(userId: string, range: DateRange) {
       avgMargin: revenue > 0 ? round((netProfit / revenue) * 100) : 0,
       avgProfitPerItem: sold.length ? round(netProfit / sold.length) : 0,
       sellThroughRate: round(sellThrough),
+    },
+    byAcquisition: {
+      bought: { revenue: round(boughtRevenue), count: boughtCount },
+      own: { revenue: round(ownRevenue), count: ownCount },
     },
     itemProfits: itemProfits.sort((a, b) => b.netProfit - a.netProfit),
     byCategory: Array.from(byCategory, ([category, v]) => ({


### PR DESCRIPTION
Closes #46.

## Summary
- **`/profit`**: new `All | Bought | Own` SegmentedControl bound to `?type=`. When `type=All`, the cost-composition donut gains a quiet "Wardrobe revenue" slice (muted slate) only when both types contributed in the period, plus a footnote on the Summary card — *"Of which £X.XX (N items) was from your own goods."* When scoped, every aggregate / chart / table is filtered.
- **`/bestsellers`**: same `?type=` filter. For `type=Own`, the meaningless median-margin% tile and group-table column are replaced with a "Mean sold for" mean — margin's not a fair gauge when cost is forced to 0.
- **`/dashboard`**: the top-profit table keeps showing **all** items but labels own ones with a small "Own" chip (decision below). Headline tiles untouched — reporting depth lives on `/profit`.
- **Analytics**: `computeProfit`, `computeProfitSeries`, and `computeBestsellers` take an optional `acquisitionType` filter applied as a `where` clause through `userScope`. `computeProfit` now also returns a `byAcquisition` split; `computeBestsellers` exposes `meanSoldPrice` on groups/overall.

## Dashboard decision
Issue #46 originally read *"Top-profit table excludes own items by default (or labels them with a chip)… Calvin to confirm."* Yesterday's call was *"be able to report on the distinction"* — least-surprise is to show everything with a label. Excluding would mean items silently disappear from the table; the chip makes the source explicit without hiding data. Reporting depth still lives on `/profit` where the filter can scope properly.

## Test plan
- [ ] On `/profit`, switch `All / Bought / Own` and confirm tiles, donut, line chart, breakdowns, and items-in-range table all rescope.
- [ ] With both bought and own sales in the period, verify the muted "Wardrobe revenue" slice appears in the donut and the footnote shows under Summary.
- [ ] On `/bestsellers?type=own`, confirm the margin column / tile is replaced by "Mean sold for" and group bars no longer render.
- [ ] On `/dashboard`, confirm "Own" chips render next to wardrobe items in the top-profit table; headline tiles untouched.
- [ ] Bookmark a filtered URL (`/profit?preset=tax_year&type=own`) and confirm it round-trips.
- [ ] Verify `/profit` still fits 1280×800 — filter sits beside the preset selector, no extra row added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)