### PR TITLE
Photos: write new uploads to Vercel Blob (phase 1) (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@clerk/nextjs": "^7.2.9",
     "@neondatabase/serverless": "^1.1.0",
+    "@vercel/blob": "^2.3.3",
     "drizzle-orm": "^0.45.2",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)
@@ -1279,6 +1282,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1341,6 +1348,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2030,6 +2040,10 @@ packages:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
 
@@ -2072,6 +2086,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2503,6 +2520,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2660,6 +2681,10 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -2726,6 +2751,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -3704,6 +3733,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.25.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3795,6 +3832,10 @@ snapshots:
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -4589,6 +4630,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-bun-module@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -4631,6 +4674,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -5050,6 +5095,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   run-parallel@1.2.0:
@@ -5264,6 +5311,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  throttleit@2.1.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.16:
@@ -5353,6 +5402,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@6.25.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -62,7 +62,14 @@ export default async function DashboardPage() {
   const hasThumb = await userScope(userId).getItemHasThumbnailMap(
     topProfit.map((p) => p.id),
   );
-  const topThumbs = topProfit.map((p) => ({ ...p, hasThumbnail: hasThumb.get(p.id) ?? false }));
+  const topThumbs = topProfit.map((p) => {
+    const t = hasThumb.get(p.id);
+    return {
+      ...p,
+      hasThumbnail: t?.hasThumbnail ?? false,
+      thumbnailUrl: t?.thumbnailUrl ?? null,
+    };
+  });
 
   return (
     <div className="space-y-8">
@@ -175,7 +182,7 @@ export default async function DashboardPage() {
                           <span className="relative inline-flex h-9 w-9 shrink-0 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
                             {p.hasThumbnail ? (
                               <Image
-                                src={`/api/inventory/thumb/${p.id}`}
+                                src={p.thumbnailUrl ?? `/api/inventory/thumb/${p.id}`}
                                 alt=""
                                 width={36}
                                 height={36}

--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -228,6 +228,7 @@ type Row = {
   listedPrice: string | null;
   soldPrice: string | null;
   hasThumbnail: boolean;
+  thumbnailUrl: string | null;
 };
 
 function Thumb({ row, size = 40 }: { row: Row; size?: number }) {
@@ -236,7 +237,7 @@ function Thumb({ row, size = 40 }: { row: Row; size?: number }) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
       <img
-        src={`/api/inventory/thumb/${row.id}`}
+        src={row.thumbnailUrl ?? `/api/inventory/thumb/${row.id}`}
         alt=""
         loading="lazy"
         style={{ width: px, height: px }}
@@ -350,7 +351,7 @@ function GridView({ rows }: { rows: Row[] }) {
                 {r.hasThumbnail ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
-                    src={`/api/inventory/thumb/${r.id}`}
+                    src={r.thumbnailUrl ?? `/api/inventory/thumb/${r.id}`}
                     alt=""
                     loading="lazy"
                     className="h-full w-full object-cover"

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -339,7 +339,9 @@ export default async function ProfitPage({
                 </thead>
                 <tbody>
                   {r.itemProfits.map((p) => {
-                    const hasThumbnail = thumbMap.get(p.id) ?? false;
+                    const thumbInfo = thumbMap.get(p.id);
+                    const hasThumbnail = thumbInfo?.hasThumbnail ?? false;
+                    const thumbnailUrl = thumbInfo?.thumbnailUrl ?? null;
                     return (
                       <tr
                         key={p.id}
@@ -353,7 +355,7 @@ export default async function ProfitPage({
                             <span className="relative inline-flex h-9 w-9 shrink-0 overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)]">
                               {hasThumbnail ? (
                                 <Image
-                                  src={`/api/inventory/thumb/${p.id}`}
+                                  src={thumbnailUrl ?? `/api/inventory/thumb/${p.id}`}
                                   alt=""
                                   width={36}
                                   height={36}

--- a/src/app/api/inventory/[id]/photos/route.ts
+++ b/src/app/api/inventory/[id]/photos/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
-import { resizeFromDataUri } from "@/lib/photos";
+import {
+  isBlobUrl,
+  resizeAndUploadFromDataUri,
+  tryDeleteBlobUrl,
+  uploadThumbFromDataUri,
+} from "@/lib/photos";
 
 const MAX_PHOTOS_PER_ITEM = 10;
 const MAX_BATCH = 5;
@@ -9,8 +14,10 @@ const MAX_BATCH = 5;
 // POST /api/inventory/[id]/photos
 // Body: { photos: string[] }  — array of base64 data URIs from the client.
 // Server-resizes each one to a 1200x1200 JPEG (full) + 200x200 JPEG (thumb)
-// and appends to items.photoUrls. Sets items.thumbnailUrl from the first
-// uploaded photo if it's currently empty.
+// and uploads both to Vercel Blob.  We persist the public Blob URLs into
+// items.photoUrls / items.thumbnailUrl.  Existing rows in the database
+// can still hold legacy data: URIs and continue to render via the proxy
+// route — a backfill is phase 2.
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -57,26 +64,35 @@ export async function POST(
     );
   }
 
-  const resized = await Promise.all(
-    incoming.slice(0, slotsLeft).map((p) => resizeFromDataUri(p)),
-  );
-  const ok = resized.filter(
-    (r): r is { full: string; thumb: string } => r != null,
-  );
-  if (ok.length === 0) {
+  let uploaded: { full: string; thumb: string }[];
+  try {
+    const results = await Promise.all(
+      incoming
+        .slice(0, slotsLeft)
+        .map((p) => resizeAndUploadFromDataUri(p, userId, id)),
+    );
+    uploaded = results.filter(
+      (r): r is { full: string; thumb: string } => r != null,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "upload failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+
+  if (uploaded.length === 0) {
     return NextResponse.json(
       { error: "could not decode any of the provided photos" },
       { status: 400 },
     );
   }
 
-  const nextPhotos = [...existing, ...ok.map((r) => r.full)];
-  const nextThumb = item.thumbnailUrl || ok[0].thumb;
+  const nextPhotos = [...existing, ...uploaded.map((r) => r.full)];
+  const nextThumb = item.thumbnailUrl || uploaded[0].thumb;
   const [updated] = await scope.setItemPhotos(id, nextPhotos, nextThumb);
 
   return NextResponse.json({
-    added: ok.length,
-    skipped: incoming.length - ok.length,
+    added: uploaded.length,
+    skipped: incoming.length - uploaded.length,
     photoCount: nextPhotos.length,
     item: updated,
   });
@@ -114,25 +130,56 @@ export async function DELETE(
     return NextResponse.json({ error: "index out of range" }, { status: 400 });
   }
 
+  const removed = photos[index];
   const next = photos.filter((_, i) => i !== index);
-  // If we removed the first photo, refresh the thumbnail from the new first.
-  // (Cheaper than re-resizing — we keep the existing thumbnail bytes if
-  // it wasn't index 0.)
+
+  // Re-derive the thumbnail when we removed the first photo.  For new (Blob)
+  // first photos we have to upload a fresh thumb because the original `full`
+  // is already an https URL — re-resizing in-memory isn't possible without
+  // re-fetching it.  In that case we just point the thumbnail at the new
+  // first photo (the CDN copy is the 1200px full; using it as a thumb is
+  // sub-optimal but cheap and correct).  For legacy base64 rows we still
+  // run sharp the way the old code did.
   let nextThumb: string | null = item.thumbnailUrl;
+  let oldThumbToDelete: string | null = null;
   if (index === 0) {
     if (next.length === 0) {
+      oldThumbToDelete = item.thumbnailUrl;
       nextThumb = null;
     } else {
-      // Re-derive a thumb from the new first photo. Lazy: just store the
-      // full data URI as the thumbnail. The /thumb endpoint resizes
-      // on-demand anyway. Cleaner approach is to re-run sharp here, but
-      // that's a memory spike on a delete; defer until we move to blob.
-      const { resizeFromDataUri } = await import("@/lib/photos");
-      const resized = await resizeFromDataUri(next[0]);
-      nextThumb = resized?.thumb ?? next[0];
+      const firstNext = next[0];
+      if (firstNext.startsWith("data:")) {
+        const reThumb = await uploadThumbFromDataUri(firstNext, userId, id).catch(
+          () => null,
+        );
+        // If blob upload failed (no token in dev), fall back to using the
+        // legacy data URI as the thumb — keeps behaviour for legacy rows.
+        nextThumb = reThumb ?? firstNext;
+      } else {
+        nextThumb = firstNext;
+      }
+      // The old thumb is only safe to delete if it differs from what we're
+      // setting now and isn't referenced elsewhere in photoUrls.
+      if (
+        item.thumbnailUrl &&
+        item.thumbnailUrl !== nextThumb &&
+        !next.includes(item.thumbnailUrl)
+      ) {
+        oldThumbToDelete = item.thumbnailUrl;
+      }
     }
   }
+
   const [updated] = await scope.setItemPhotos(id, next, nextThumb);
+
+  // Best-effort blob cleanup after the DB has been updated.  Failures are
+  // swallowed inside tryDeleteBlobUrl.
+  const toDelete: string[] = [];
+  if (isBlobUrl(removed)) toDelete.push(removed);
+  if (oldThumbToDelete && isBlobUrl(oldThumbToDelete)) {
+    toDelete.push(oldThumbToDelete);
+  }
+  await Promise.all(toDelete.map((u) => tryDeleteBlobUrl(u)));
 
   return NextResponse.json({
     removed: index,

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -169,6 +169,9 @@ export function userScope(userId: string) {
         status: items.status,
         platform: items.platform,
         hasThumbnail: sql<boolean>`${items.thumbnailUrl} IS NOT NULL`.as("has_thumbnail"),
+        // Only ship URL across wire when it's a CDN URL — legacy base64
+        // entries are huge, so we resolve those via the proxy route.
+        thumbnailUrl: sql<string | null>`CASE WHEN ${items.thumbnailUrl} LIKE 'http%' THEN ${items.thumbnailUrl} ELSE NULL END`.as("thumb_url"),
         description: items.description,
         sourceType: items.sourceType,
         sourceLocation: items.sourceLocation,
@@ -308,20 +311,31 @@ export function userScope(userId: string) {
       return out;
     },
 
-    /** Return a Map<id, hasThumbnail> in one round-trip — cheap because we
-     *  only select the boolean, not the bytes. Use this any time you need
-     *  to know which of N items have thumbnails (e.g. dashboard, lists). */
+    /** Return a Map<id, { hasThumbnail, thumbnailUrl }> in one round-trip.
+     *  We only ship the URL across the wire when it's an https CDN URL —
+     *  legacy base64 entries return `thumbnailUrl: null` to keep payloads
+     *  tiny (callers fall back to the /api/inventory/thumb/[id] proxy).
+     *  `hasThumbnail` covers both cases. */
     getItemHasThumbnailMap: async (ids: string[]) => {
-      const out = new Map<string, boolean>();
+      const out = new Map<
+        string,
+        { hasThumbnail: boolean; thumbnailUrl: string | null }
+      >();
       if (ids.length === 0) return out;
       const rows = await db
         .select({
           id: items.id,
           hasThumbnail: sql<boolean>`${items.thumbnailUrl} IS NOT NULL`.as("has_thumbnail"),
+          thumbnailUrl: sql<string | null>`CASE WHEN ${items.thumbnailUrl} LIKE 'http%' THEN ${items.thumbnailUrl} ELSE NULL END`.as("thumb_url"),
         })
         .from(items)
         .where(and(eq(items.userId, userId), inArray(items.id, ids)));
-      for (const r of rows) out.set(r.id, !!r.hasThumbnail);
+      for (const r of rows) {
+        out.set(r.id, {
+          hasThumbnail: !!r.hasThumbnail,
+          thumbnailUrl: r.thumbnailUrl ?? null,
+        });
+      }
       return out;
     },
 

--- a/src/lib/photos.ts
+++ b/src/lib/photos.ts
@@ -1,16 +1,34 @@
 import sharp from "sharp";
+import { put, del } from "@vercel/blob";
 
 // Full-size: 1200x1200 JPEG q70 (~200-400 KB). Detail views.
 // Thumbnail: 200x200 JPEG q60 (~10-20 KB). List cards.
-// Both stored as base64 data URIs in items.photoUrls / items.thumbnailUrl
-// so we don't yet need a blob store.
+//
+// Phase 1 (this file): new uploads write to Vercel Blob and we persist the
+// public CDN URLs into items.photoUrls / items.thumbnailUrl. Existing rows
+// from the legacy world still hold `data:image/...;base64,...` strings;
+// readers branch on the prefix (see `thumbSrc`).
 
 const DATA_URI_RE = /^data:(image\/[^;]+);base64,(.+)$/;
 
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+function assertBlobToken(): string {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    throw new Error(
+      "BLOB_READ_WRITE_TOKEN is not set. A Vercel Blob store must be " +
+        "provisioned and the token added to the environment before photos " +
+        "can be uploaded.",
+    );
+  }
+  return token;
+}
+
 export async function resizePhotoBuffer(
   buffer: Buffer,
-): Promise<{ full: string; thumb: string }> {
-  const [fullBuf, thumbBuf] = await Promise.all([
+): Promise<{ full: Buffer; thumb: Buffer }> {
+  const [full, thumb] = await Promise.all([
     sharp(buffer)
       .resize(1200, 1200, { fit: "inside", withoutEnlargement: true })
       .jpeg({ quality: 70 })
@@ -20,13 +38,115 @@ export async function resizePhotoBuffer(
       .jpeg({ quality: 60 })
       .toBuffer(),
   ]);
-
-  return {
-    full: `data:image/jpeg;base64,${fullBuf.toString("base64")}`,
-    thumb: `data:image/jpeg;base64,${thumbBuf.toString("base64")}`,
-  };
+  return { full, thumb };
 }
 
+/** Resize an incoming data-URI client upload, push both versions to Vercel
+ *  Blob, and return the resulting public URLs.  Throws if the Blob token
+ *  isn't configured — we want loud failure, not a silent fallback. */
+export async function resizeAndUploadFromDataUri(
+  dataUri: string,
+  userId: string,
+  itemId: string,
+): Promise<{ full: string; thumb: string } | null> {
+  const match = dataUri.match(DATA_URI_RE);
+  if (!match) return null;
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(match[2], "base64");
+  } catch {
+    return null;
+  }
+
+  const token = assertBlobToken();
+  const { full, thumb } = await resizePhotoBuffer(buffer);
+
+  const basePath = `items/${userId}/${itemId}`;
+  const [fullRes, thumbRes] = await Promise.all([
+    put(`${basePath}/photo.jpeg`, full, {
+      access: "public",
+      contentType: "image/jpeg",
+      addRandomSuffix: true,
+      cacheControlMaxAge: ONE_YEAR_SECONDS,
+      token,
+    }),
+    put(`${basePath}/photo-thumb.jpeg`, thumb, {
+      access: "public",
+      contentType: "image/jpeg",
+      addRandomSuffix: true,
+      cacheControlMaxAge: ONE_YEAR_SECONDS,
+      token,
+    }),
+  ]);
+
+  return { full: fullRes.url, thumb: thumbRes.url };
+}
+
+/** Resize a buffer that's already been decoded (used by the thumb-rederive
+ *  path inside DELETE) and upload only a thumbnail.  Returns the URL. */
+export async function uploadThumbFromDataUri(
+  dataUri: string,
+  userId: string,
+  itemId: string,
+): Promise<string | null> {
+  const match = dataUri.match(DATA_URI_RE);
+  if (!match) return null;
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(match[2], "base64");
+  } catch {
+    return null;
+  }
+  const token = assertBlobToken();
+  const { thumb } = await resizePhotoBuffer(buffer);
+  const res = await put(
+    `items/${userId}/${itemId}/photo-thumb.jpeg`,
+    thumb,
+    {
+      access: "public",
+      contentType: "image/jpeg",
+      addRandomSuffix: true,
+      cacheControlMaxAge: ONE_YEAR_SECONDS,
+      token,
+    },
+  );
+  return res.url;
+}
+
+/** True when `value` is a Vercel Blob CDN URL we own. */
+export function isBlobUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return /^https?:\/\/[^/]*blob\.vercel-storage\.com\//.test(value);
+}
+
+/** Best-effort delete of a Blob URL.  No-ops on non-blob inputs (legacy
+ *  base64 entries). Errors are swallowed — orphan blobs are tolerable, a
+ *  failed user delete is not. */
+export async function tryDeleteBlobUrl(value: string): Promise<void> {
+  if (!isBlobUrl(value)) return;
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) return;
+  try {
+    await del(value, { token });
+  } catch {
+    // Swallow — leave the orphan.  Logging would be nice but the route's
+    // contract is "the photo is gone from the user's view".
+  }
+}
+
+/** Decide what `<img src>` to use for a thumbnail.  New uploads have https
+ *  Blob URLs and we serve them from the CDN.  Legacy base64 rows go via
+ *  the per-user proxy at /api/inventory/thumb/[id]. */
+export function thumbSrc(itemId: string, thumbnailUrl: string | null | undefined): string {
+  if (thumbnailUrl && /^https?:\/\//.test(thumbnailUrl)) return thumbnailUrl;
+  return `/api/inventory/thumb/${itemId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy helpers — kept for the thumb proxy route + DELETE rederive path.
+// ---------------------------------------------------------------------------
+
+/** Legacy: resize a base64 data URI in-memory and return both as data URIs. */
 export async function resizeFromDataUri(
   dataUri: string,
 ): Promise<{ full: string; thumb: string } | null> {
@@ -34,7 +154,11 @@ export async function resizeFromDataUri(
   if (!match) return null;
   try {
     const buffer = Buffer.from(match[2], "base64");
-    return await resizePhotoBuffer(buffer);
+    const { full, thumb } = await resizePhotoBuffer(buffer);
+    return {
+      full: `data:image/jpeg;base64,${full.toString("base64")}`,
+      thumb: `data:image/jpeg;base64,${thumb.toString("base64")}`,
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Phase 1 of the migration from base64-in-Postgres to Vercel Blob for item photos. New uploads are resized server-side, pushed to Vercel Blob with `addRandomSuffix: true` and a 1-year `cacheControlMaxAge`, and the resulting public CDN URLs are persisted into `items.photoUrls` and `items.thumbnailUrl`. Existing rows holding `data:image/jpeg;base64,...` strings keep rendering via the existing `/api/inventory/thumb/[id]` proxy.

- New `src/lib/photos.ts` exports `resizeAndUploadFromDataUri`, `uploadThumbFromDataUri`, `tryDeleteBlobUrl`, `isBlobUrl`, and `thumbSrc`.
- `POST /api/inventory/[id]/photos` resizes + uploads to Blob (path: `items/<userId>/<itemId>/photo[-thumb].jpeg`). Failure modes (missing token, blob 5xx) bubble up as 500 with a clear message.
- `DELETE /api/inventory/[id]/photos` calls `del()` for any Blob-backed URL it removes (the photo + the previous thumbnail when the first photo is removed). Legacy base64 entries are left alone.
- `getItemHasThumbnailMap` and `listItems` now also return `thumbnailUrl` (only when the stored value starts with `http`, via SQL `CASE`) so the existing payload doesn't bloat with base64 strings. Dashboard, inventory list/grid, and profit table use the URL directly when present and fall back to the proxy route otherwise.
- No schema changes. The columns already accept arbitrary strings.
- Backup / restore endpoints unchanged — they roundtrip whatever string is in the column, which works for both base64 and https URLs.

## Before merging

This PR will build but uploads will fail at runtime without a Blob token configured.

- [ ] Provision a Vercel Blob store via the Marketplace (Storage tab on the project).
- [ ] Set `BLOB_READ_WRITE_TOKEN` in **Production**, **Preview**, and **Development** env contexts (`vercel env add` or via dashboard).
- [ ] Pull locally: `vercel env pull` so dev uploads work too.

The route fails loudly (500 with `BLOB_READ_WRITE_TOKEN is not set...`) rather than silently writing base64 — by design.

## Phase 2 follow-up (separate issue)

- Backfill existing base64 `photoUrls` / `thumbnailUrl` entries to Blob (one-shot script + idempotent re-runs).
- After backfill, delete `src/app/api/inventory/thumb/[id]/route.ts` and the SQL `CASE WHEN ... LIKE 'http%'` projections (everything will be a URL).
- Remove the legacy `resizeFromDataUri` / `decodeDataUri` helpers from `src/lib/photos.ts`.

## Test plan

- [ ] With `BLOB_READ_WRITE_TOKEN` set: upload a new photo on an existing item; verify the URL stored in `photoUrls` is `https://*.blob.vercel-storage.com/...` and the image renders on the detail page.
- [ ] Verify the thumbnail in the inventory list loads directly from blob storage (network tab — no `/api/inventory/thumb/...` request for new uploads).
- [ ] Delete a photo on a Blob-backed item; verify it's gone from the gallery and (if you have access) the blob is gone from the store.
- [ ] On a Lily-imported item with legacy base64 photos, verify the detail gallery still renders and the inventory list thumbnail still loads via `/api/inventory/thumb/[id]`.
- [ ] Without `BLOB_READ_WRITE_TOKEN`: upload returns 500 with a clear error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)