### PR TITLE
Loading skeletons for main app pages (perf #1/5)

### DIFF
--- a/src/app/(app)/bestsellers/loading.tsx
+++ b/src/app/(app)/bestsellers/loading.tsx
@@ -1,0 +1,60 @@
+// Lightweight skeleton — instant Suspense fallback while /bestsellers data loads.
+
+const tile = "h-[112px] rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4";
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function BestsellersLoading() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+            Best sellers
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-72`} />
+        </div>
+        <div className="flex items-center gap-3">
+          <div className={`${ghost} h-9 w-44`} />
+          <div className={`${ghost} h-9 w-32`} />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className={tile}>
+            <div className={`${ghost} h-3 w-24`} />
+            <div className={`${ghost} mt-3 h-7 w-20`} />
+            <div className={`${ghost} mt-2 h-3 w-16`} />
+          </div>
+        ))}
+      </section>
+
+      <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+        <div className={`${ghost} h-5 w-44`} />
+        <div className={`${ghost} mt-2 h-3 w-80`} />
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <div className={`${ghost} h-9 w-72`} />
+          <div className={`${ghost} h-9 w-44`} />
+        </div>
+        <div className="mt-5 space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className={`${ghost} h-10 w-full`} />
+          ))}
+        </div>
+      </div>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {Array.from({ length: 2 }).map((_, c) => (
+          <div key={c} className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+            <div className={`${ghost} h-5 w-40`} />
+            <div className="mt-4 space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className={`${ghost} h-10 w-full`} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,57 @@
+// Lightweight skeleton — instant Suspense fallback while dashboard data loads.
+// No data, no auth, no imports from app components. Mirrors page.tsx layout.
+
+const tile = "h-[112px] rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4";
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+            Dashboard
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-32`} />
+        </div>
+        <div className="flex gap-2">
+          <div className={`${ghost} h-8 w-20`} />
+          <div className={`${ghost} h-8 w-24`} />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className={tile}>
+            <div className={`${ghost} h-3 w-24`} />
+            <div className={`${ghost} mt-3 h-7 w-28`} />
+            <div className={`${ghost} mt-2 h-3 w-20`} />
+          </div>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)]">
+          <div className="flex items-center justify-between p-5 pb-3">
+            <div className={`${ghost} h-5 w-44`} />
+            <div className={`${ghost} h-3 w-16`} />
+          </div>
+          <div className="space-y-2 px-5 pb-5">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className={`${ghost} h-9 w-full`} />
+            ))}
+          </div>
+        </div>
+        <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+          <div className={`${ghost} h-5 w-32`} />
+          <div className={`${ghost} mt-2 h-3 w-48`} />
+          <div className="mt-4 space-y-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={`${ghost} h-10 w-full`} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/health/loading.tsx
+++ b/src/app/(app)/health/loading.tsx
@@ -1,0 +1,44 @@
+// Lightweight skeleton — instant Suspense fallback while /health data loads.
+
+const tile = "h-[112px] rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4";
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function HealthLoading() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+            Inventory health
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-80`} />
+        </div>
+        <div className={`${ghost} h-3 w-40`} />
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className={tile}>
+            <div className={`${ghost} h-3 w-28`} />
+            <div className={`${ghost} mt-3 h-7 w-20`} />
+            <div className={`${ghost} mt-2 h-3 w-32`} />
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+            <div className={`${ghost} h-5 w-40`} />
+            <div className={`${ghost} mt-2 h-3 w-56`} />
+            <div className={`${ghost} mt-4 h-32 w-full`} />
+            <div className="mt-3 space-y-2">
+              <div className={`${ghost} h-3 w-full`} />
+              <div className={`${ghost} h-3 w-3/4`} />
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/inventory/loading.tsx
+++ b/src/app/(app)/inventory/loading.tsx
@@ -1,0 +1,57 @@
+// Lightweight skeleton — instant Suspense fallback while /inventory data loads.
+
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function InventoryLoading() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+            Inventory
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-48`} />
+        </div>
+        <div className={`${ghost} h-8 w-24`} />
+      </header>
+
+      <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className={`${ghost} h-9 flex-1 min-w-[220px]`} />
+          <div className={`${ghost} h-9 w-32`} />
+          <div className={`${ghost} h-9 w-32`} />
+          <div className={`${ghost} h-9 w-28`} />
+          <div className={`${ghost} ml-auto h-9 w-20`} />
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <div className={`${ghost} h-8 w-32`} />
+      </div>
+
+      <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)]">
+        <div className="flex items-center gap-4 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]/40 px-4 py-3">
+          <div className={`${ghost} h-3 w-16`} />
+          <div className={`${ghost} h-3 w-24`} />
+          <div className={`${ghost} h-3 w-16`} />
+          <div className={`${ghost} h-3 w-12`} />
+          <div className={`${ghost} h-3 w-16`} />
+          <div className={`${ghost} ml-auto h-3 w-20`} />
+        </div>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b border-[var(--border-subtle)] px-4 py-3 last:border-0"
+          >
+            <div className={`${ghost} h-10 w-10`} />
+            <div className={`${ghost} h-4 w-48`} />
+            <div className={`${ghost} h-3 w-20`} />
+            <div className={`${ghost} h-3 w-12`} />
+            <div className={`${ghost} h-5 w-16`} />
+            <div className={`${ghost} ml-auto h-3 w-16`} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/plan/loading.tsx
+++ b/src/app/(app)/plan/loading.tsx
@@ -1,0 +1,55 @@
+// Lightweight skeleton — instant Suspense fallback while /plan data loads.
+
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function PlanLoading() {
+  return (
+    <div className="space-y-8 animate-pulse">
+      <header className="flex items-end justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--text-primary)]">
+            Plan my day
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-44`} />
+        </div>
+        <div className="text-right">
+          <div className={`${ghost} ml-auto h-3 w-20`} />
+          <div className={`${ghost} mt-2 ml-auto h-6 w-24`} />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4">
+            <div className={`${ghost} h-3 w-16`} />
+            <div className={`${ghost} mt-3 h-7 w-10`} />
+          </div>
+        ))}
+      </section>
+
+      {Array.from({ length: 3 }).map((_, s) => (
+        <section key={s}>
+          <div className="mb-2 flex items-center gap-2">
+            <div className={`${ghost} h-5 w-20`} />
+            <div className={`${ghost} h-3 w-12`} />
+          </div>
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-3 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-3"
+              >
+                <div className={`${ghost} h-10 w-10`} />
+                <div className="flex-1 space-y-2">
+                  <div className={`${ghost} h-4 w-1/2`} />
+                  <div className={`${ghost} h-3 w-1/3`} />
+                </div>
+                <div className={`${ghost} h-8 w-20`} />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/profit/loading.tsx
+++ b/src/app/(app)/profit/loading.tsx
@@ -1,0 +1,51 @@
+// Lightweight skeleton — instant Suspense fallback while /profit data loads.
+
+const tile = "h-[112px] rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4";
+const ghost = "rounded-[var(--radius-sm)] bg-[var(--surface-muted)]";
+
+export default function ProfitLoading() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+            Profit
+          </h1>
+          <div className={`${ghost} mt-2 h-3 w-40`} />
+        </div>
+        <div className="flex items-center gap-3">
+          <div className={`${ghost} h-9 w-44`} />
+          <div className={`${ghost} h-9 w-32`} />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-7">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className={tile}>
+            <div className={`${ghost} h-3 w-20`} />
+            <div className={`${ghost} mt-3 h-6 w-24`} />
+            <div className={`${ghost} mt-2 h-3 w-16`} />
+          </div>
+        ))}
+      </section>
+
+      <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+        <div className={`${ghost} h-5 w-56`} />
+        <div className={`${ghost} mt-2 h-3 w-72`} />
+        <div className={`${ghost} mt-4 h-44 w-full`} />
+      </div>
+
+      <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)]">
+        <div className="flex items-center justify-between border-b border-[var(--border-subtle)] p-4">
+          <div className={`${ghost} h-8 w-72`} />
+          <div className={`${ghost} h-8 w-48`} />
+        </div>
+        <div className="space-y-2 p-5">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className={`${ghost} h-9 w-full`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
First of 5 perf fixes from \`~/shared/markviewer/relist-saas/2026-05-06-perf-audit.md\`.

## Why

App Router default is to render Server Components and stream — but with no \`loading.tsx\` boundary, the browser waits for the *full* RSC render before showing anything. On nav, that = blank → page appears, which Calvin reads as "lag." Adding loading.tsx flips this to skeleton-instantly-then-content.

## What

Six new \`loading.tsx\` files, all pure-presentational, no auth/data, animate-pulse on the root, matching real-page layouts to minimise content-shift:

- \`src/app/(app)/dashboard/loading.tsx\` — title + 4-tile row + top profit table + quick actions
- \`src/app/(app)/profit/loading.tsx\` — title + 7-tile grid + chart card + tabbed Card
- \`src/app/(app)/inventory/loading.tsx\` — title + filters + ViewToggle + 8-row table
- \`src/app/(app)/plan/loading.tsx\` — title + 4 count tiles + 3 task sections
- \`src/app/(app)/bestsellers/loading.tsx\` — title + 4 tiles + breakdown card + hall-of-fame
- \`src/app/(app)/health/loading.tsx\` — title + 4 tiles + 3-column section

All use existing CSS tokens (--surface-card, --surface-muted, --border-subtle), all under 80 lines.

## Verified

- \`pnpm exec tsc --noEmit\` clean
- \`pnpm lint\` no new errors (3 pre-existing on main, unrelated)

## Test plan

- [ ] Click nav between Dashboard / Profit / Inventory / Plan / Bestsellers / Health on \`relist-saas.warmwetcircles.com\` — each transition should feel instant: skeleton appears immediately, real content lands.
- [ ] Skeleton layout closely matches the real page (no content-jump on hydrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)