### PR TITLE
Auto-apply filter changes; remove Apply buttons (perf #2/5)

### DIFF
--- a/src/app/(app)/bestsellers/PresetSelect.tsx
+++ b/src/app/(app)/bestsellers/PresetSelect.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Option = { value: string; label: string };
+
+/** Auto-submitting preset select for /bestsellers. Preserves dim/sort/type
+ *  from the current URL via useSearchParams; replaces (not pushes) the URL
+ *  so back button doesn't fill up. /bestsellers isn't paginated. */
+export function PresetSelect({
+  options,
+  value,
+}: {
+  options: Option[];
+  value: string;
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => {
+        const sp = new URLSearchParams(params?.toString() ?? "");
+        const next = e.target.value;
+        if (next) sp.set("preset", next);
+        else sp.delete("preset");
+        const qs = sp.toString();
+        router.replace(qs ? `/bestsellers?${qs}` : "/bestsellers", {
+          scroll: false,
+        });
+      }}
+      className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm"
+      aria-label="Date range preset"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/(app)/bestsellers/page.tsx
+++ b/src/app/(app)/bestsellers/page.tsx
@@ -16,6 +16,7 @@ import {
   SegmentedControl,
   Tile,
 } from "@/components/ui";
+import { PresetSelect } from "./PresetSelect";
 
 const PRESETS = [
   { value: "this_month", label: "This month" },
@@ -147,29 +148,7 @@ export default async function BestsellersPage({
                 buildHref({ preset, dim: dimension, sort: sortKey, type: v })
               }
             />
-          <form className="flex items-center gap-2 text-sm">
-            <input type="hidden" name="dim" value={dimension} />
-            <input type="hidden" name="sort" value={sortKey} />
-            <input type="hidden" name="type" value={typeFilter} />
-            <select
-              name="preset"
-              defaultValue={preset}
-              className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm"
-              aria-label="Date range preset"
-            >
-              {PRESETS.map((p) => (
-                <option key={p.value} value={p.value}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
-            <button
-              type="submit"
-              className="inline-flex h-9 items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--surface-muted)]"
-            >
-              Apply
-            </button>
-          </form>
+          <PresetSelect options={PRESETS} value={preset} />
           </div>
         }
       />

--- a/src/app/(app)/expenses/PresetSelect.tsx
+++ b/src/app/(app)/expenses/PresetSelect.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Option = { value: string; label: string };
+
+/** Auto-submitting preset select for /expenses. Replaces the URL on change. */
+export function PresetSelect({
+  options,
+  value,
+}: {
+  options: Option[];
+  value: string;
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => {
+        const sp = new URLSearchParams(params?.toString() ?? "");
+        const next = e.target.value;
+        if (next) sp.set("preset", next);
+        else sp.delete("preset");
+        const qs = sp.toString();
+        router.replace(qs ? `/expenses?${qs}` : "/expenses", { scroll: false });
+      }}
+      className="rounded-md border px-2 py-1"
+      aria-label="Date range preset"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { userScope } from "@/lib/db/scoped";
 import { resolveDateRange } from "@/lib/date-range";
 import { ExpensesClient } from "./client";
+import { PresetSelect } from "./PresetSelect";
 
 const PRESETS = [
   { value: "", label: "All time" },
@@ -42,20 +43,7 @@ export default async function ExpensesPage({
             Business costs: packaging and shipping supplies.
           </p>
         </div>
-        <form className="flex gap-2 text-sm">
-          <select
-            name="preset"
-            defaultValue={preset}
-            className="rounded-md border px-2 py-1"
-          >
-            {PRESETS.map((p) => (
-              <option key={p.value} value={p.value}>
-                {p.label}
-              </option>
-            ))}
-          </select>
-          <button className="rounded-md border px-3 py-1">Apply</button>
-        </form>
+        <PresetSelect options={PRESETS} value={preset} />
       </header>
 
       <section className="grid grid-cols-2 gap-4 md:grid-cols-4">

--- a/src/app/(app)/inventory/FiltersBar.tsx
+++ b/src/app/(app)/inventory/FiltersBar.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type StatusOption = { value: string; label: string };
+
+/** Auto-applying filter bar for /inventory. Selects + checkbox commit
+ *  immediately; the search input debounces 300ms. Every change resets
+ *  ?page=1 and uses router.replace({ scroll: false }) so the back button
+ *  stays sane. The "view" param (table/grid) is preserved. */
+export function FiltersBar({
+  initialSearch,
+  initialStatus,
+  initialSort,
+  initialIncomplete,
+  statusOptions,
+}: {
+  initialSearch: string;
+  initialStatus: string;
+  initialSort: string;
+  initialIncomplete: boolean;
+  statusOptions: StatusOption[];
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const [search, setSearch] = useState(initialSearch);
+  const [status, setStatus] = useState(initialStatus);
+  const [sort, setSort] = useState(initialSort);
+  const [incomplete, setIncomplete] = useState(initialIncomplete);
+
+  // Track the most-recent submitted search so the debounce doesn't race
+  // a fresh URL change.
+  const lastPushedSearch = useRef(initialSearch);
+
+  function pushUrl(next: {
+    search: string;
+    status: string;
+    sort: string;
+    incomplete: boolean;
+  }) {
+    const sp = new URLSearchParams(params?.toString() ?? "");
+    if (next.search.trim()) sp.set("search", next.search.trim());
+    else sp.delete("search");
+    if (next.status && next.status !== "listed") sp.set("status", next.status);
+    else sp.delete("status");
+    if (next.sort && next.sort !== "date") sp.set("sort", next.sort);
+    else sp.delete("sort");
+    if (next.incomplete) sp.set("incomplete", "1");
+    else sp.delete("incomplete");
+    sp.delete("page");
+    const qs = sp.toString();
+    router.replace(qs ? `/inventory?${qs}` : "/inventory", { scroll: false });
+  }
+
+  // Debounce search input.
+  useEffect(() => {
+    if (search === lastPushedSearch.current) return;
+    const t = setTimeout(() => {
+      lastPushedSearch.current = search;
+      pushUrl({ search, status, sort, incomplete });
+    }, 300);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-sm">
+      <input
+        type="search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search name, brand, SKU…"
+        className="min-w-[220px] flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
+      />
+      <label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+        <span className="hidden sm:inline">Status</span>
+        <select
+          value={status}
+          onChange={(e) => {
+            const next = e.target.value;
+            setStatus(next);
+            lastPushedSearch.current = search;
+            pushUrl({ search, status: next, sort, incomplete });
+          }}
+          className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-2.5 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none"
+        >
+          {statusOptions.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+        <span className="hidden sm:inline">Sort by</span>
+        <select
+          value={sort}
+          onChange={(e) => {
+            const next = e.target.value;
+            setSort(next);
+            lastPushedSearch.current = search;
+            pushUrl({ search, status, sort: next, incomplete });
+          }}
+          className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-2.5 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none"
+        >
+          <option value="date">Newest</option>
+          <option value="price">Price</option>
+          <option value="brand">Brand</option>
+        </select>
+      </label>
+      <label className="flex items-center gap-1.5 px-1 text-xs text-[var(--text-secondary)]">
+        <input
+          type="checkbox"
+          checked={incomplete}
+          onChange={(e) => {
+            const next = e.target.checked;
+            setIncomplete(next);
+            lastPushedSearch.current = search;
+            pushUrl({ search, status, sort, incomplete: next });
+          }}
+          className="h-3.5 w-3.5 rounded border-[var(--border-default)] text-[var(--brand)]"
+        />
+        Incomplete only
+      </label>
+    </div>
+  );
+}

--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -11,6 +11,7 @@ import {
   ViewToggle,
 } from "@/components/ui";
 import { StatusTransitionButton } from "./StatusTransitionButton";
+import { FiltersBar } from "./FiltersBar";
 
 const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: "all", label: "All statuses" },
@@ -104,56 +105,13 @@ export default async function InventoryPage({
       />
 
       <Card padded className="p-4">
-        <form className="flex flex-wrap items-center gap-2 text-sm">
-          <input
-            type="search"
-            name="search"
-            defaultValue={sp.search ?? ""}
-            placeholder="Search name, brand, SKU…"
-            className="min-w-[220px] flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
-          />
-          <label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-            <span className="hidden sm:inline">Status</span>
-            <select
-              name="status"
-              defaultValue={statusParam}
-              className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-2.5 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none"
-            >
-              {STATUS_OPTIONS.map((s) => (
-                <option key={s.value} value={s.value}>
-                  {s.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-            <span className="hidden sm:inline">Sort by</span>
-            <select
-              name="sort"
-              defaultValue={sort}
-              className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-2.5 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--brand)] focus:outline-none"
-            >
-              <option value="date">Newest</option>
-              <option value="price">Price</option>
-              <option value="brand">Brand</option>
-            </select>
-          </label>
-          <label className="flex items-center gap-1.5 px-1 text-xs text-[var(--text-secondary)]">
-            <input
-              type="checkbox"
-              name="incomplete"
-              value="1"
-              defaultChecked={sp.incomplete === "1"}
-              className="h-3.5 w-3.5 rounded border-[var(--border-default)] text-[var(--brand)]"
-            />
-            Incomplete only
-          </label>
-          {/* preserve view in form submissions */}
-          {view === "grid" && <input type="hidden" name="view" value="grid" />}
-          <button className="ml-auto rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 py-2 text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--surface-muted)]">
-            Apply
-          </button>
-        </form>
+        <FiltersBar
+          initialSearch={sp.search ?? ""}
+          initialStatus={statusParam}
+          initialSort={sort}
+          initialIncomplete={sp.incomplete === "1"}
+          statusOptions={STATUS_OPTIONS}
+        />
       </Card>
 
       <div className="flex items-center justify-end">

--- a/src/app/(app)/profit/PresetSelect.tsx
+++ b/src/app/(app)/profit/PresetSelect.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Option = { value: string; label: string };
+
+/** Auto-submitting preset select for /profit. Replaces the URL on change so
+ *  the back button doesn't fill up; resets ?page=1 because the Items tab is
+ *  paginated. */
+export function PresetSelect({
+  options,
+  value,
+}: {
+  options: Option[];
+  value: string;
+}) {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => {
+        const sp = new URLSearchParams(params?.toString() ?? "");
+        const next = e.target.value;
+        if (next && next !== "this_month") sp.set("preset", next);
+        else sp.delete("preset");
+        sp.delete("page");
+        const qs = sp.toString();
+        router.replace(qs ? `/profit?${qs}` : "/profit", { scroll: false });
+      }}
+      className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm text-[var(--text-primary)]"
+      aria-label="Date range preset"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui";
 import { RevenueVsCostsChart } from "./charts";
 import { ItemsSearch } from "./ItemsSearch";
+import { PresetSelect } from "./PresetSelect";
 import type { AcquisitionType } from "@/db/schema";
 
 const PRESETS = [
@@ -209,27 +210,7 @@ export default async function ProfitPage({
               tone="brand"
               hrefFor={(v) => buildHref(p, { type: v, page: 1 })}
             />
-            <form className="flex items-center gap-2 text-sm">
-              {p.type !== "all" && <input type="hidden" name="type" value={p.type} />}
-              {p.tab !== "items" && <input type="hidden" name="tab" value={p.tab} />}
-              <select
-                name="preset"
-                defaultValue={p.preset}
-                className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm text-[var(--text-primary)]"
-              >
-                {PRESETS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="submit"
-                className="h-9 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 text-sm font-medium hover:bg-[var(--surface-muted)]"
-              >
-                Apply
-              </button>
-            </form>
+            <PresetSelect options={PRESETS} value={p.preset} />
           </div>
         }
       />


### PR DESCRIPTION
Second of 5 perf fixes. Calvin hates clicking Apply after every filter change. Replace the form-with-Apply pattern with onChange auto-navigate.

## What changed

- **/profit** — preset select now in \`PresetSelect.tsx\` (client). Reads URL params, calls \`router.replace({ scroll: false })\` on change. Resets \`?page=1\` because the Items tab is paginated.
- **/bestsellers** — same pattern. Hidden \`dim\`/\`sort\`/\`type\` inputs no longer needed; the component reads them from the URL.
- **/expenses** — same pattern.
- **/inventory** — replaced the multi-control form (search / status / sort / incomplete / Apply) with \`FiltersBar.tsx\`. Status/sort/incomplete commit on change; search debounces 300ms (mirroring the existing ItemsSearch pattern). Page reset to 1 on every change. View toggle untouched.

All new client components use \`router.replace()\` (not push) so the back button doesn't fill up with every filter tweak.

## Verified

- \`pnpm exec tsc --noEmit\` clean.
- \`pnpm lint\` no NEW errors. The 4 pre-existing errors on main (react-hooks/set-state-in-effect in MarkAsSoldPopover, ItemsSearch, AnimatedDashboard×2) are unrelated and not introduced by this PR.

## Test plan

- [ ] /profit: change preset → page reloads with new range, no Apply click.
- [ ] /bestsellers: change preset → page reloads.
- [ ] /expenses: change preset → page reloads.
- [ ] /inventory: change status/sort/incomplete → reloads instantly; type in search → URL updates after 300ms.
- [ ] On every page above, back button restores the prior filter state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)