### PR TITLE
Analytics indexes + SQL filter pushdown (perf #3+#4/5)

### DIFF
--- a/drizzle/0007_salty_princess_powerful.sql
+++ b/drizzle/0007_salty_princess_powerful.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "items_user_status_sold_idx" ON "items" USING btree ("user_id","status","sold_at");--> statement-breakpoint
+CREATE INDEX "items_user_acquisition_idx" ON "items" USING btree ("user_id","acquisition_type");--> statement-breakpoint
+CREATE INDEX "items_user_source_idx" ON "items" USING btree ("user_id","source_type");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1161 @@
+{
+  "id": "d90e2fd0-f38d-4853-be4c-9114a3662ec7",
+  "prevId": "d5ab8726-90d7-42e1-9228-a24a8b158d7f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_hash_unique": {
+          "name": "api_keys_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incurred_at": {
+          "name": "incurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "expenses_user_incurred_idx": {
+          "name": "expenses_user_incurred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_category_idx": {
+          "name": "expenses_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "expenses_user_sample_idx": {
+          "name": "expenses_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_type": {
+          "name": "acquisition_type",
+          "type": "acquisition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bought'"
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_price": {
+          "name": "listed_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_price": {
+          "name": "sold_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sourced'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'vinted'"
+        },
+        "photo_urls": {
+          "name": "photo_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_location": {
+          "name": "source_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinted_url": {
+          "name": "vinted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold_at": {
+          "name": "sold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buyer_paid_shipping": {
+          "name": "buyer_paid_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_at": {
+          "name": "last_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relist_count": {
+          "name": "relist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_user_status_idx": {
+          "name": "items_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sample_idx": {
+          "name": "items_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_brand_idx": {
+          "name": "items_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_category_idx": {
+          "name": "items_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_created_idx": {
+          "name": "items_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_listed_idx": {
+          "name": "items_user_listed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_sold_idx": {
+          "name": "items_user_sold_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sold_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_status_sold_idx": {
+          "name": "items_user_status_sold_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sold_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_acquisition_idx": {
+          "name": "items_user_acquisition_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acquisition_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_user_source_idx": {
+          "name": "items_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_data": {
+      "name": "price_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_minor": {
+          "name": "price_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_payload": {
+          "name": "raw_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_data_user_observed_idx": {
+          "name": "price_data_user_observed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_brand_idx": {
+          "name": "price_data_user_brand_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "price_data_user_source_external_idx": {
+          "name": "price_data_user_source_external_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_stats": {
+      "name": "price_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_size": {
+          "name": "sample_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "median_minor": {
+          "name": "median_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p25_minor": {
+          "name": "p25_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p75_minor": {
+          "name": "p75_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean_minor": {
+          "name": "mean_minor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GBP'"
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "price_stats_user_bucket_idx": {
+          "name": "price_stats_user_bucket_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gross_price": {
+          "name": "gross_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_cost": {
+          "name": "shipping_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "platform_fees": {
+          "name": "platform_fees",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "profit": {
+          "name": "profit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sample": {
+          "name": "is_sample",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_item_idx": {
+          "name": "transactions_user_item_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_completed_idx": {
+          "name": "transactions_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_sample_idx": {
+          "name": "transactions_user_sample_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_sample",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_item_id_items_id_fk": {
+          "name": "transactions_item_id_items_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_key_idx": {
+          "name": "user_settings_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.acquisition_type": {
+      "name": "acquisition_type",
+      "schema": "public",
+      "values": [
+        "bought",
+        "own"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777928975583,
       "tag": "0006_short_chronomancer",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778089164817,
+      "tag": "0007_salty_princess_powerful",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -129,6 +129,12 @@ export const items = pgTable(
     index("items_user_created_idx").on(t.userId, t.createdAt),
     index("items_user_listed_idx").on(t.userId, t.listedAt),
     index("items_user_sold_idx").on(t.userId, t.soldAt),
+    // Analytics-shaped composite indexes (perf audit, May 2026):
+    // /profit and /bestsellers commonly read sold-or-shipped rows in a date
+    // range, optionally scoped to acquisitionType or sourceType.
+    index("items_user_status_sold_idx").on(t.userId, t.status, t.soldAt),
+    index("items_user_acquisition_idx").on(t.userId, t.acquisitionType),
+    index("items_user_source_idx").on(t.userId, t.sourceType),
   ],
 );
 

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, or } from "drizzle-orm";
+import { and, eq, gte, inArray, lte, or } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
@@ -49,13 +49,16 @@ export async function computeBestsellers(
   range: DateRange,
   acquisitionType?: AcquisitionType,
 ) {
-  // Pull sold + shipped items in the user's scope; we filter by soldAt range
-  // in JS so the schema's soldAt nullable case stays explicit.
+  // Push the date range into SQL so we don't load every historical sale.
+  // listedAt nullability is filtered in JS (no SQL-side IS NOT NULL needed
+  // — Postgres uses the (user_id, status, sold_at) index here regardless).
   const conds = [
     eq(items.userId, userId),
     or(eq(items.status, "sold"), eq(items.status, "shipped"))!,
   ];
   if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
+  if (range.from) conds.push(gte(items.soldAt, range.from));
+  if (range.to) conds.push(lte(items.soldAt, range.to));
   const rows = await db
     .select({
       id: items.id,
@@ -73,12 +76,7 @@ export async function computeBestsellers(
     .from(items)
     .where(and(...conds));
 
-  const inRange = rows.filter((r) => {
-    if (!r.listedAt || !r.soldAt) return false;
-    if (range.from && r.soldAt < range.from) return false;
-    if (range.to && r.soldAt > range.to) return false;
-    return true;
-  });
+  const inRange = rows.filter((r) => r.listedAt != null && r.soldAt != null);
 
   const ids = inRange.map((r) => r.id);
   const txns = ids.length

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, lte, inArray, or } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
@@ -38,8 +38,15 @@ export async function computeProfitSeries(
   range: DateRange,
   acquisitionType?: AcquisitionType,
 ): Promise<ProfitSeriesPoint[]> {
-  const conds = [eq(items.userId, userId)];
+  // Only sold/shipped rows contribute to the series. Filter in SQL so we
+  // never load listed/sourced rows for /profit charts.
+  const conds = [
+    eq(items.userId, userId),
+    or(eq(items.status, "sold"), eq(items.status, "shipped"))!,
+  ];
   if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
+  if (range.from) conds.push(gte(items.soldAt, range.from));
+  if (range.to) conds.push(lte(items.soldAt, range.to));
   const sold = await db
     .select({
       id: items.id,
@@ -88,10 +95,9 @@ export async function computeProfitSeries(
     return i >= 0 && i < points.length ? i : -1;
   };
 
-  // Item-level sale data
+  // Item-level sale data. Status + soldAt are already filtered in SQL above.
   const itemBy: Record<string, { idx: number; cost: number; sold: number }> = {};
   for (const it of sold) {
-    if (it.status !== "sold" && it.status !== "shipped") continue;
     if (!it.soldAt) continue;
     const i = idxFor(it.soldAt as Date);
     if (i < 0) continue;
@@ -102,7 +108,8 @@ export async function computeProfitSeries(
     itemBy[it.id] = { idx: i, cost: c, sold: s };
   }
 
-  // Transactions for shipping
+  // Transactions for shipping — scope to the in-window item IDs so we don't
+  // pull every historical sell transaction for the user.
   const itemIds = Object.keys(itemBy);
   if (itemIds.length) {
     const txns = await db
@@ -115,6 +122,7 @@ export async function computeProfitSeries(
         and(
           eq(transactions.userId, userId),
           eq(transactions.transactionType, "sell"),
+          inArray(transactions.itemId, itemIds),
         ),
       );
     for (const t of txns) {

--- a/src/lib/analytics/profit.ts
+++ b/src/lib/analytics/profit.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, lte, inArray } from "drizzle-orm";
+import { and, eq, gte, lte, inArray, or } from "drizzle-orm";
 import { db } from "@/db/client";
 import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
@@ -22,36 +22,56 @@ export async function computeProfit(
   range: DateRange,
   acquisitionType?: AcquisitionType,
 ) {
-  const conds = [eq(items.userId, userId)];
-  if (acquisitionType) conds.push(eq(items.acquisitionType, acquisitionType));
-  const allItems = await db
-    .select({
-      id: items.id,
-      name: items.name,
-      brand: items.brand,
-      category: items.category,
-      status: items.status,
-      costPrice: items.costPrice,
-      listedPrice: items.listedPrice,
-      soldPrice: items.soldPrice,
-      soldAt: items.soldAt,
-      listedAt: items.listedAt,
-      sourceType: items.sourceType,
-      acquisitionType: items.acquisitionType,
-    })
-    .from(items)
-    .where(and(...conds));
+  // Two queries: in-range sold/shipped (revenue side) and current stock
+  // (listed/sourced, no date filter). Splitting lets us push the date range
+  // into SQL for the sold side without losing the stock-value calculation.
+  const baseScope = [eq(items.userId, userId)];
+  if (acquisitionType) baseScope.push(eq(items.acquisitionType, acquisitionType));
 
-  const hasFilter = range.from != null || range.to != null;
-  const sold = allItems.filter((i) => {
-    if (i.status !== "sold" && i.status !== "shipped") return false;
-    if (hasFilter && !i.soldAt) return false;
-    if (range.from && i.soldAt && i.soldAt < range.from) return false;
-    if (range.to && i.soldAt && i.soldAt > range.to) return false;
-    return true;
-  });
-  const listed = allItems.filter((i) => i.status === "listed");
-  const sourced = allItems.filter((i) => i.status === "sourced");
+  const soldConds = [
+    ...baseScope,
+    or(eq(items.status, "sold"), eq(items.status, "shipped"))!,
+  ];
+  // When a range is set, also require soldAt IS NOT NULL — pre-existing
+  // behaviour treated null soldAt as out-of-range.
+  if (range.from) soldConds.push(gte(items.soldAt, range.from));
+  if (range.to) soldConds.push(lte(items.soldAt, range.to));
+
+  const stockConds = [
+    ...baseScope,
+    or(eq(items.status, "listed"), eq(items.status, "sourced"))!,
+  ];
+
+  const [soldRows, stockRows] = await Promise.all([
+    db
+      .select({
+        id: items.id,
+        name: items.name,
+        brand: items.brand,
+        category: items.category,
+        status: items.status,
+        costPrice: items.costPrice,
+        soldPrice: items.soldPrice,
+        soldAt: items.soldAt,
+        sourceType: items.sourceType,
+        acquisitionType: items.acquisitionType,
+      })
+      .from(items)
+      .where(and(...soldConds)),
+    db
+      .select({
+        id: items.id,
+        status: items.status,
+        costPrice: items.costPrice,
+        listedPrice: items.listedPrice,
+      })
+      .from(items)
+      .where(and(...stockConds)),
+  ]);
+
+  const sold = soldRows;
+  const listed = stockRows.filter((i) => i.status === "listed");
+  const sourced = stockRows.filter((i) => i.status === "sourced");
 
   const soldIds = sold.map((i) => i.id);
   const txns = soldIds.length


### PR DESCRIPTION
Tasks 3 and 4 from \`~/shared/markviewer/relist-saas/2026-05-06-perf-audit.md\`. Stops the analytics compute functions from loading the full \`items\` table on every page load, and adds the composite indexes those filtered queries need to scale.

## Indexes (drizzle/0007)

- \`items_user_status_sold_idx (user_id, status, sold_at)\` — /profit and /bestsellers in-range sold/shipped scans.
- \`items_user_acquisition_idx (user_id, acquisition_type)\` — bought/own filter on /profit and /bestsellers.
- \`items_user_source_idx (user_id, source_type)\` — /bestsellers source dimension.

## SQL filter pushdown

- **profit.ts**: split the single \`allItems\` load into two parallel queries — one for sold/shipped in range (date filter pushed into WHERE), one for listed/sourced stock (no date filter). Acquisition-type filter was already in SQL.
- **profit-series.ts**: status filter pushed into SQL via \`or(status='sold', status='shipped')\`; sold_at range pushed in when set. Transactions query now scoped to in-window itemIds via \`inArray\` instead of loading every historical sell-transaction for the user.
- **bestsellers.ts**: sold_at range pushed into SQL.

No behavioural change. /health and /plan analytics already correctly filter by status in SQL — left untouched.

## Migration deployment

Will run automatically via the \`postbuild\` script (\`pnpm db:migrate\`) once main is built on Vercel. Indexes use \`CREATE INDEX\` (not \`IF NOT EXISTS\`) — first apply only.

## Test plan

- [ ] Tenancy CI check passes.
- [ ] /profit, /profit/?type=bought, /profit/?preset=tax_year, /profit/?type=own&preset=last_90_days all render the same numbers as before (spot-check totals).
- [ ] /bestsellers loads and shows the same hall-of-fame.
- [ ] Mark an item sold → /dashboard, /profit, /bestsellers all reflect it after the existing revalidatePath fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)