### PR TITLE
Cache analytics compute with unstable_cache + tag invalidation (perf #5/5)

### DIFF
--- a/src/app/(app)/inventory/status-actions.ts
+++ b/src/app/(app)/inventory/status-actions.ts
@@ -4,6 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 import { userScope } from "@/lib/db/scoped";
 import { coerceMoney } from "@/lib/money";
+import { revalidateUserItems } from "@/lib/analytics/cache";
 
 type Status = "sourced" | "listed" | "sold" | "shipped";
 
@@ -70,6 +71,7 @@ export async function markItemSoldAction(
   revalidatePath("/inventory");
   revalidatePath(`/inventory/${id}`);
   revalidatePath("/dashboard");
+  revalidateUserItems(userId);
   return { ok: true };
 }
 
@@ -106,4 +108,5 @@ export async function transitionItemStatusAction(
   revalidatePath("/inventory");
   revalidatePath(`/inventory/${id}`);
   revalidatePath("/dashboard");
+  revalidateUserItems(userId);
 }

--- a/src/app/api/expenses/[id]/route.ts
+++ b/src/app/api/expenses/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
+import { revalidateUserItems } from "@/lib/analytics/cache";
 
 export const runtime = "nodejs";
 
@@ -22,5 +23,6 @@ export async function DELETE(
   if (rows.length === 0) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  revalidateUserItems(userId);
   return NextResponse.json({ deleted: true });
 }

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
 import { resolveDateRange } from "@/lib/date-range";
+import { revalidateUserItems } from "@/lib/analytics/cache";
 
 export const runtime = "nodejs";
 
@@ -62,7 +63,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const [expense] = await userScope(u.userId).insertExpense({
+  const userId = u.userId;
+  const [expense] = await userScope(userId).insertExpense({
     category: parsed.data.category,
     description: parsed.data.description ?? null,
     amount: parsed.data.amount,
@@ -70,5 +72,6 @@ export async function POST(req: NextRequest) {
     incurredAt: new Date(parsed.data.incurredAt),
   });
 
+  revalidateUserItems(userId);
   return NextResponse.json({ expense }, { status: 201 });
 }

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
 import { coerceMoney } from "@/lib/money";
+import { revalidateUserItems } from "@/lib/analytics/cache";
 
 export const runtime = "nodejs";
 
@@ -125,6 +126,7 @@ export async function PATCH(
     });
   }
 
+  revalidateUserItems(u.userId);
   return NextResponse.json({ item: updated });
 }
 
@@ -139,5 +141,6 @@ export async function DELETE(
   if (rows.length === 0) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  revalidateUserItems(u.userId);
   return NextResponse.json({ deleted: true });
 }

--- a/src/app/api/inventory/route.ts
+++ b/src/app/api/inventory/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getUserId, UnauthorizedError } from "@/lib/auth/getUserId";
 import { userScope } from "@/lib/db/scoped";
+import { revalidateUserItems } from "@/lib/analytics/cache";
 
 export const runtime = "nodejs";
 
@@ -104,6 +105,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ item: existing, updated: false });
     }
     const [updated] = await scope.updateItem(existing.id, updates);
+    revalidateUserItems(u.userId);
     return NextResponse.json({ item: updated, updated: true });
   }
 
@@ -132,5 +134,6 @@ export async function POST(req: NextRequest) {
     listedAt: status === "listed" ? now : null,
   });
 
+  revalidateUserItems(u.userId);
   return NextResponse.json({ item }, { status: 201 });
 }

--- a/src/lib/analytics/bestsellers.ts
+++ b/src/lib/analytics/bestsellers.ts
@@ -3,6 +3,7 @@ import { db } from "@/db/client";
 import { items, transactions, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
+import { withUserItemsCache } from "./cache";
 
 export const MIN_GROUP_SIZE = 2;
 
@@ -44,7 +45,7 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-export async function computeBestsellers(
+async function _computeBestsellers(
   userId: string,
   range: DateRange,
   acquisitionType?: AcquisitionType,
@@ -187,3 +188,5 @@ export async function computeBestsellers(
 
   return { overall, groups, topFastest, topProfit, minGroupSize: MIN_GROUP_SIZE };
 }
+
+export const computeBestsellers = withUserItemsCache(_computeBestsellers, "bestsellers");

--- a/src/lib/analytics/cache.ts
+++ b/src/lib/analytics/cache.ts
@@ -1,0 +1,47 @@
+/**
+ * Thin user-scoped wrapper around Next.js's `unstable_cache`. Used by the
+ * heavier analytics compute functions (computeProfit, computeBestsellers,
+ * computeProfitSeries) so repeat-navigation between /dashboard, /profit,
+ * /bestsellers within a few seconds doesn't redo the same DB work.
+ *
+ * Cache key is automatically derived from the wrapped function's args plus
+ * the explicit key array. Tags are user-scoped so one user's mutation never
+ * invalidates another user's cache.
+ *
+ * Server actions and API routes that mutate items / transactions / expenses
+ * call `revalidateUserItems(userId)` to drop the cached aggregates.
+ */
+import { unstable_cache, revalidateTag } from "next/cache";
+
+const REVALIDATE_SECONDS = 60;
+
+export function userItemsTag(userId: string): string {
+  return `user:items:${userId}`;
+}
+
+/** Drop every analytics cache entry that depends on this user's items /
+ *  transactions / expenses. Cheap to call; safe to call from anywhere on
+ *  the server. Uses the "default" cacheLife profile so behaviour matches
+ *  unstable_cache TTLs configured here. */
+export function revalidateUserItems(userId: string): void {
+  revalidateTag(userItemsTag(userId), "default");
+}
+
+/** Wrap a compute function whose first arg is `userId`. All args are part
+ *  of the cache key automatically; the explicit key prefix lets us
+ *  namespace different compute functions for the same user. */
+export function withUserItemsCache<
+  Args extends [userId: string, ...rest: unknown[]],
+  R,
+>(
+  fn: (...args: Args) => Promise<R>,
+  key: string,
+): (...args: Args) => Promise<R> {
+  return async (...args: Args): Promise<R> => {
+    const [userId] = args;
+    return unstable_cache(fn, [key, userId], {
+      tags: [userItemsTag(userId)],
+      revalidate: REVALIDATE_SECONDS,
+    })(...args);
+  };
+}

--- a/src/lib/analytics/profit-series.ts
+++ b/src/lib/analytics/profit-series.ts
@@ -3,6 +3,7 @@ import { db } from "@/db/client";
 import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
+import { withUserItemsCache } from "./cache";
 
 const num = coerceMoney;
 
@@ -33,7 +34,7 @@ function startOfDay(d: Date) {
  *
  * User-scoped: we filter by userId on every table read.
  */
-export async function computeProfitSeries(
+async function _computeProfitSeries(
   userId: string,
   range: DateRange,
   acquisitionType?: AcquisitionType,
@@ -150,3 +151,5 @@ export async function computeProfitSeries(
 
   return points;
 }
+
+export const computeProfitSeries = withUserItemsCache(_computeProfitSeries, "profit-series");

--- a/src/lib/analytics/profit.ts
+++ b/src/lib/analytics/profit.ts
@@ -3,6 +3,7 @@ import { db } from "@/db/client";
 import { items, transactions, expenses, type AcquisitionType } from "@/db/schema";
 import type { DateRange } from "@/lib/date-range";
 import { coerceMoney } from "@/lib/money";
+import { withUserItemsCache } from "./cache";
 
 const num = coerceMoney;
 const round = (n: number) => Math.round(n * 100) / 100;
@@ -17,7 +18,7 @@ export type ProfitReport = Awaited<ReturnType<typeof computeProfit>>;
  * `acquisitionType` (optional) scopes every aggregate to bought-only or own-only
  * items. When omitted, both contribute. See issue #46.
  */
-export async function computeProfit(
+async function _computeProfit(
   userId: string,
   range: DateRange,
   acquisitionType?: AcquisitionType,
@@ -237,3 +238,5 @@ export async function computeProfit(
     })).sort((a, b) => b.amount - a.amount),
   };
 }
+
+export const computeProfit = withUserItemsCache(_computeProfit, "profit");


### PR DESCRIPTION
Last of the 5 perf fixes from \`~/shared/markviewer/relist-saas/2026-05-06-perf-audit.md\`.

\`computeProfit\`, \`computeProfitSeries\` and \`computeBestsellers\` are wrapped with \`unstable_cache\` so repeat-navigation between /dashboard /profit /bestsellers within the same minute reuses the cached aggregates instead of redoing the SQL work.

## How it works

- Per-function key prefix ("profit", "profit-series", "bestsellers") combined with the wrapped function's args (userId, range, acquisitionType) form the cache key.
- Tag pattern: \`user:items:\${userId}\` — shared across all three so a single \`revalidateUserItems(userId)\` invalidates everything.
- Revalidate window: 60s (safety net if a mutation forgets to invalidate).
- New helper: \`src/lib/analytics/cache.ts\`.

## Mutation paths that now invalidate

- \`src/app/(app)/inventory/status-actions.ts\` (markItemSold + transitionItemStatus)
- \`src/app/api/inventory/route.ts\` (POST + dedupe-update branch)
- \`src/app/api/inventory/[id]/route.ts\` (PATCH + DELETE)
- \`src/app/api/expenses/route.ts\` (POST)
- \`src/app/api/expenses/[id]/route.ts\` (DELETE)

Existing \`revalidatePath\` calls remain — those invalidate the page render cache; this adds the data-layer cache on top.

## Next 16 note

\`revalidateTag\` in Next 16 takes \`(tag, profile)\`. We pass \`"default"\` so behaviour aligns with the configured 60s revalidate window.

## Test plan

- [ ] Navigate /dashboard → /profit → /bestsellers → back. After the first hit, repeat-nav should feel cached (DB queries should be skipped — observable via Vercel function logs).
- [ ] Mark an item sold from /inventory. Within seconds, /dashboard, /profit, /bestsellers reflect the new sale (both the page render and the cached aggregate are invalidated).
- [ ] Add an expense via the extension. /profit shows it immediately.
- [ ] Even if invalidation is missed somewhere, the 60s TTL ensures stale data clears within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)