### PR TITLE
Health: explicit missing-field chips + jump-to-field edit (#58)

### DIFF
--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -99,8 +99,8 @@ export default async function HealthPage() {
   const isFirstRun = itemCount === 0;
   const totalAging = Object.values(h.aging.buckets).reduce((a, b) => a + b, 0);
 
-  // Enrich biggestImpact rows with item names (one round-trip).
-  const impactIds = h.completeness.biggestImpact.map((b) => b.itemId);
+  // Enrich topGaps rows with item names (one round-trip).
+  const impactIds = h.completeness.topGaps.map((g) => g.itemId);
   const nameMap = await scope.getItemNamesByIds(impactIds);
 
   const paceTone = PACE_TONE[h.cadence.paceBand];
@@ -300,39 +300,48 @@ export default async function HealthPage() {
             title="Biggest completeness wins"
             description="Fix one field to bump these the most."
           />
-          {h.completeness.biggestImpact.length === 0 ? (
+          {h.completeness.topGaps.length === 0 ? (
             <p className="mt-6 text-sm text-[var(--accent-emerald-soft-fg)]">
               Everything is complete.
             </p>
           ) : (
             <ul className="mt-3 divide-y divide-[var(--border-subtle)]">
-              {h.completeness.biggestImpact.slice(0, 5).map((b) => {
-                const band = scoreBand(b.score);
-                const name = nameMap.get(b.itemId) ?? b.itemId;
+              {h.completeness.topGaps.slice(0, 5).map((g) => {
+                const band = scoreBand(g.score);
+                const name = nameMap.get(g.itemId) ?? g.itemId;
                 return (
-                  <li key={b.itemId} className="py-2.5">
-                    <Link
-                      href={`/inventory/${b.itemId}`}
-                      className="group flex items-center justify-between gap-3"
-                    >
+                  <li key={g.itemId} className="py-2.5">
+                    <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium text-[var(--text-primary)] group-hover:underline">
+                        <Link
+                          href={`/inventory/${g.itemId}`}
+                          className="block truncate text-sm font-medium text-[var(--text-primary)] hover:underline"
+                        >
                           {name}
-                        </p>
-                        <p className="mt-0.5 text-xs">
-                          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-amber-soft)] px-1.5 py-0.5 font-medium text-[var(--accent-amber-soft-fg)]">
-                            +{b.missingWeight} {b.missingLabel}
-                          </span>
-                        </p>
+                        </Link>
+                        <ul className="mt-1 flex flex-wrap gap-1">
+                          {g.missing.map((m) => (
+                            <li key={m.field}>
+                              <Link
+                                href={`/inventory/${g.itemId}?focus=${m.field}`}
+                                title={`+${m.weight} pts · ${m.hint}`}
+                                className="inline-flex items-center gap-1 rounded-[var(--radius-sm)] bg-[var(--accent-amber-soft)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--accent-amber)]/30"
+                              >
+                                <span className="tabular-nums opacity-80">+{m.weight}</span>
+                                <span>{m.label}</span>
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
                       </div>
-                      <ScoreBadge score={b.score} band={band} />
-                    </Link>
+                      <ScoreBadge score={g.score} band={band} />
+                    </div>
                   </li>
                 );
               })}
             </ul>
           )}
-          {h.completeness.biggestImpact.length > 0 && (
+          {h.completeness.topGaps.length > 0 && (
             <Link
               href="/inventory?incomplete=1"
               className="mt-3 block text-center text-xs font-medium text-[var(--brand)] hover:underline"

--- a/src/app/(app)/inventory/[id]/edit-details.tsx
+++ b/src/app/(app)/inventory/[id]/edit-details.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui";
+import {
+  scoreItem,
+  type CompletenessField,
+  type FieldStatus,
+} from "@/lib/inventory/completeness";
+
+type Initial = {
+  name: string;
+  brand: string | null;
+  category: string | null;
+  size: string | null;
+  description: string | null;
+  vintedUrl: string | null;
+  photoCount: number;
+};
+
+const FOCUS_PARAM_FIELDS: CompletenessField[] = [
+  "title",
+  "brand",
+  "category",
+  "size",
+  "description",
+  "vintedUrl",
+  "photos",
+];
+
+export function EditDetails({
+  itemId,
+  initial,
+}: {
+  itemId: string;
+  initial: Initial;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const focusParam = searchParams.get("focus") as CompletenessField | null;
+  const shouldOpen = focusParam != null && FOCUS_PARAM_FIELDS.includes(focusParam);
+
+  const [open, setOpen] = useState(shouldOpen);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: initial.name ?? "",
+    brand: initial.brand ?? "",
+    category: initial.category ?? "",
+    size: initial.size ?? "",
+    description: initial.description ?? "",
+    vintedUrl: initial.vintedUrl ?? "",
+  });
+
+  const refs = {
+    title: useRef<HTMLInputElement | null>(null),
+    brand: useRef<HTMLInputElement | null>(null),
+    category: useRef<HTMLInputElement | null>(null),
+    size: useRef<HTMLInputElement | null>(null),
+    description: useRef<HTMLTextAreaElement | null>(null),
+    vintedUrl: useRef<HTMLInputElement | null>(null),
+  };
+
+  // Auto-focus the requested field once when the section is auto-opened.
+  useEffect(() => {
+    if (!open || !focusParam) return;
+    const r = refs[focusParam as keyof typeof refs] as
+      | { current: HTMLElement | null }
+      | undefined;
+    if (r?.current) {
+      r.current.focus();
+      r.current.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+    // photos doesn't have a field here — fall through to the photo grid above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Live completeness preview as the user types.
+  const preview = scoreItem({
+    name: form.name,
+    brand: form.brand || null,
+    category: form.category || null,
+    size: form.size || null,
+    description: form.description || null,
+    photoCount: initial.photoCount,
+    vintedUrl: form.vintedUrl || null,
+  });
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      const payload: Record<string, string | null> = {
+        name: form.name.trim() || null,
+        brand: form.brand.trim() || null,
+        category: form.category.trim() || null,
+        size: form.size.trim() || null,
+        description: form.description.trim() || null,
+        vintedUrl: form.vintedUrl.trim() || null,
+      };
+      const res = await fetch(`/api/inventory/${itemId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(body?.error ?? `Save failed (${res.status})`);
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-[var(--text-primary)]">
+            Listing details
+          </h2>
+          <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+            {preview.score === 100
+              ? "All seven completeness fields are filled."
+              : `${preview.missing.length} field${preview.missing.length === 1 ? "" : "s"} missing — completeness ${preview.score}/100.`}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-[var(--radius-md)] border border-[var(--border-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--text-secondary)] hover:border-[var(--border-default)] hover:text-[var(--text-primary)]"
+        >
+          {open ? "Close" : "Edit"}
+        </button>
+      </header>
+
+      {!open && preview.missing.length > 0 && (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {preview.missing.map((m) => (
+            <li key={m.field}>
+              <button
+                type="button"
+                onClick={() => setOpen(true)}
+                title={m.hint}
+                className="inline-flex items-center gap-1 rounded-[var(--radius-sm)] bg-[var(--accent-amber-soft)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--accent-amber)]/30"
+              >
+                <span className="tabular-nums opacity-80">+{m.weight}</span>
+                <span>{m.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {open && (
+        <form onSubmit={save} className="mt-4 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field
+              label="Title"
+              hint={fieldHint(preview.fields, "title")}
+              full
+            >
+              <input
+                ref={refs.title}
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className={inputCls}
+                disabled={busy}
+              />
+            </Field>
+            <Field label="Brand" hint={fieldHint(preview.fields, "brand")}>
+              <input
+                ref={refs.brand}
+                type="text"
+                value={form.brand}
+                onChange={(e) => setForm({ ...form, brand: e.target.value })}
+                className={inputCls}
+                disabled={busy}
+              />
+            </Field>
+            <Field label="Category" hint={fieldHint(preview.fields, "category")}>
+              <input
+                ref={refs.category}
+                type="text"
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value })}
+                className={inputCls}
+                disabled={busy}
+              />
+            </Field>
+            <Field label="Size" hint={fieldHint(preview.fields, "size")}>
+              <input
+                ref={refs.size}
+                type="text"
+                value={form.size}
+                onChange={(e) => setForm({ ...form, size: e.target.value })}
+                className={inputCls}
+                disabled={busy}
+              />
+            </Field>
+            <Field
+              label="Vinted URL"
+              hint={fieldHint(preview.fields, "vintedUrl")}
+            >
+              <input
+                ref={refs.vintedUrl}
+                type="url"
+                placeholder="https://www.vinted.co.uk/items/…"
+                value={form.vintedUrl}
+                onChange={(e) => setForm({ ...form, vintedUrl: e.target.value })}
+                className={inputCls}
+                disabled={busy}
+              />
+            </Field>
+            <Field
+              label="Description"
+              hint={fieldHint(preview.fields, "description")}
+              full
+            >
+              <textarea
+                ref={refs.description}
+                rows={4}
+                value={form.description}
+                onChange={(e) =>
+                  setForm({ ...form, description: e.target.value })
+                }
+                className={`${inputCls} min-h-[6rem] resize-y`}
+                disabled={busy}
+              />
+            </Field>
+          </div>
+
+          {error && (
+            <p className="rounded-[var(--radius-sm)] bg-[var(--accent-rose-soft)] px-2 py-1.5 text-xs text-[var(--accent-rose-soft-fg)]">
+              {error}
+            </p>
+          )}
+
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="sm" disabled={busy}>
+              {busy ? "Saving…" : "Save details"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+const inputCls =
+  "w-full rounded-[var(--radius-sm)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-2 py-1.5 text-sm focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)] disabled:opacity-50";
+
+function fieldHint(
+  fields: FieldStatus[],
+  field: CompletenessField,
+): string {
+  const f = fields.find((x) => x.field === field);
+  if (!f) return "";
+  return f.present ? `✓ ${f.label}` : `${f.label} · +${f.weight} pts`;
+}
+
+function Field({
+  label,
+  hint,
+  children,
+  full,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+  full?: boolean;
+}) {
+  return (
+    <label className={`flex flex-col gap-1 ${full ? "sm:col-span-2" : ""}`}>
+      <span className="flex items-baseline justify-between gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+          {label}
+        </span>
+        {hint && (
+          <span
+            className={`text-[10px] tabular-nums ${hint.startsWith("✓") ? "text-[var(--accent-emerald-soft-fg)]" : "text-[var(--accent-amber-soft-fg)]"}`}
+          >
+            {hint}
+          </span>
+        )}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
@@ -6,6 +7,7 @@ import { Card, StatusPill } from "@/components/ui";
 import { ItemActions } from "./actions";
 import { ItemPhotos } from "./photos";
 import { AcquisitionChip } from "./AcquisitionChip";
+import { EditDetails } from "./edit-details";
 
 function gbp(n: string | null) {
   return n == null ? "—" : `£${parseFloat(n).toFixed(2)}`;
@@ -114,17 +116,21 @@ export default async function ItemDetail({
         </div>
       </div>
 
-      {/* Description — below the fold */}
-      {item.description && (
-        <Card>
-          <h2 className="text-sm font-semibold text-[var(--text-secondary)]">
-            Description
-          </h2>
-          <p className="mt-2 whitespace-pre-wrap text-sm text-[var(--text-primary)]">
-            {item.description}
-          </p>
-        </Card>
-      )}
+      {/* Listing details — editable; supports ?focus=<field> deep-link from Health */}
+      <Suspense fallback={null}>
+        <EditDetails
+          itemId={item.id}
+          initial={{
+            name: item.name,
+            brand: item.brand,
+            category: item.category,
+            size: item.size,
+            description: item.description,
+            vintedUrl: item.vintedUrl,
+            photoCount: Array.isArray(item.photoUrls) ? item.photoUrls.length : 0,
+          }}
+        />
+      </Suspense>
 
       {/* Transactions — below the fold */}
       <Card padded={false}>

--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui";
 import { StatusTransitionButton } from "./StatusTransitionButton";
 import { FiltersBar } from "./FiltersBar";
+import { scoreItem, type FieldStatus } from "@/lib/inventory/completeness";
 
 const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: "all", label: "All statuses" },
@@ -65,6 +66,20 @@ export default async function InventoryPage({
   ]);
 
   const { rows, total, pageCount } = result;
+  const showMissingCol = sp.incomplete === "1";
+  const enriched: Row[] = rows.map((r) => {
+    if (!showMissingCol) return r as unknown as Row;
+    const { missing } = scoreItem({
+      name: r.name,
+      brand: r.brand,
+      category: r.category,
+      size: r.size,
+      description: (r as { description?: string | null }).description ?? null,
+      photoCount: Number((r as { photoCount?: number | null }).photoCount ?? 0),
+      vintedUrl: (r as { vintedUrl?: string | null }).vintedUrl ?? null,
+    });
+    return { ...(r as unknown as Row), missing };
+  });
   const filtersApplied =
     statusParam !== "listed" ||
     !!sp.search?.trim() ||
@@ -139,9 +154,9 @@ export default async function InventoryPage({
           </Card>
         )
       ) : view === "grid" ? (
-        <GridView rows={rows} />
+        <GridView rows={enriched} />
       ) : (
-        <TableView rows={rows} />
+        <TableView rows={enriched} showMissing={showMissingCol} />
       )}
 
       {rows.length > 0 && pageCount > 1 && (
@@ -187,6 +202,8 @@ type Row = {
   soldPrice: string | null;
   hasThumbnail: boolean;
   thumbnailUrl: string | null;
+  /** Populated by the inventory page when `incomplete=1`. */
+  missing?: FieldStatus[];
 };
 
 function Thumb({ row, size = 40 }: { row: Row; size?: number }) {
@@ -214,7 +231,13 @@ function Thumb({ row, size = 40 }: { row: Row; size?: number }) {
   );
 }
 
-function TableView({ rows }: { rows: Row[] }) {
+function TableView({
+  rows,
+  showMissing = false,
+}: {
+  rows: Row[];
+  showMissing?: boolean;
+}) {
   return (
     <Card padded={false} className="overflow-visible">
       <div>
@@ -223,8 +246,14 @@ function TableView({ rows }: { rows: Row[] }) {
             <tr className="border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]/40 text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
               <th className="w-16 py-3 pl-4 pr-2 font-medium">Thumbnail</th>
               <th className="py-3 pr-4 font-medium">Item</th>
-              <th className="py-3 pr-4 font-medium">Brand</th>
-              <th className="py-3 pr-4 font-medium">Size</th>
+              {showMissing ? (
+                <th className="py-3 pr-4 font-medium">Missing</th>
+              ) : (
+                <>
+                  <th className="py-3 pr-4 font-medium">Brand</th>
+                  <th className="py-3 pr-4 font-medium">Size</th>
+                </>
+              )}
               <th className="py-3 pr-4 font-medium">Status</th>
               <th className="py-3 pr-4 text-right font-medium">Cost</th>
               <th className="py-3 pr-4 text-right font-medium">Listed</th>
@@ -260,12 +289,20 @@ function TableView({ rows }: { rows: Row[] }) {
                     </div>
                   )}
                 </td>
-                <td className="py-3 pr-4 text-[var(--text-secondary)]">
-                  {r.brand ?? "—"}
-                </td>
-                <td className="py-3 pr-4 text-[var(--text-secondary)]">
-                  {r.size ?? "—"}
-                </td>
+                {showMissing ? (
+                  <td className="py-3 pr-4">
+                    <MissingChips itemId={r.id} missing={r.missing ?? []} />
+                  </td>
+                ) : (
+                  <>
+                    <td className="py-3 pr-4 text-[var(--text-secondary)]">
+                      {r.brand ?? "—"}
+                    </td>
+                    <td className="py-3 pr-4 text-[var(--text-secondary)]">
+                      {r.size ?? "—"}
+                    </td>
+                  </>
+                )}
                 <td className="py-3 pr-4">
                   <StatusPill status={r.status} />
                 </td>
@@ -349,6 +386,38 @@ function GridView({ rows }: { rows: Row[] }) {
               </div>
             </div>
           </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function MissingChips({
+  itemId,
+  missing,
+}: {
+  itemId: string;
+  missing: FieldStatus[];
+}) {
+  if (missing.length === 0) {
+    return (
+      <span className="inline-flex items-center rounded-[var(--radius-sm)] bg-[var(--accent-emerald-soft)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--accent-emerald-soft-fg)]">
+        Complete
+      </span>
+    );
+  }
+  return (
+    <ul className="flex flex-wrap gap-1">
+      {missing.map((m) => (
+        <li key={m.field}>
+          <Link
+            href={`/inventory/${itemId}?focus=${m.field}`}
+            title={`+${m.weight} pts · ${m.hint}`}
+            className="inline-flex items-center gap-1 rounded-[var(--radius-sm)] bg-[var(--accent-amber-soft)] px-1.5 py-0.5 text-[11px] font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--accent-amber)]/30"
+          >
+            <span className="tabular-nums opacity-80">+{m.weight}</span>
+            <span>{m.label}</span>
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -174,6 +174,7 @@ export function userScope(userId: string) {
         sourceType: items.sourceType,
         sourceLocation: items.sourceLocation,
         vintedUrl: items.vintedUrl,
+        photoCount: sql<number>`COALESCE(array_length(${items.photoUrls}, 1), 0)`.as("photo_count"),
         listedAt: items.listedAt,
         soldAt: items.soldAt,
         buyerPaidShipping: items.buyerPaidShipping,
@@ -185,17 +186,28 @@ export function userScope(userId: string) {
         isSample: items.isSample,
       };
 
-      // incompleteOnly is a post-filter (multi-column NULL/empty-string check)
-      // — when set we skip SQL pagination and let the page render the slice.
+      // incompleteOnly post-filters using the same scoring rules as the Health
+      // page — i.e. any of the seven completeness fields below target. Skips
+      // SQL pagination and lets the page render the slice.
       if (incompleteOnly) {
+        const { scoreItem } = await import("@/lib/inventory/completeness");
         const all = await db
           .select(cols)
           .from(items)
           .where(and(...conds))
           .orderBy(orderBy);
-        const filtered = all.filter(
-          (r) => !r.brand || !r.category || !r.size || !r.condition || !r.listedPrice,
-        );
+        const filtered = all.filter((r) => {
+          const { score } = scoreItem({
+            name: r.name,
+            brand: r.brand,
+            category: r.category,
+            size: r.size,
+            description: r.description,
+            photoCount: Number(r.photoCount ?? 0),
+            vintedUrl: r.vintedUrl,
+          });
+          return score < 100;
+        });
         return {
           rows: filtered,
           total: filtered.length,

--- a/src/lib/inventory/completeness.ts
+++ b/src/lib/inventory/completeness.ts
@@ -18,13 +18,20 @@ export const WEIGHTS = {
   vintedUrl: 5,
 } as const;
 
+export const PHOTO_TARGET = 3;
+export const TITLE_TARGET = 4; // words
+export const DESCRIPTION_TARGET = 40; // chars
+
 export type CompletenessField = keyof typeof WEIGHTS;
 
 export interface FieldStatus {
   field: CompletenessField;
+  /** Short chip-ready label, dynamic when partial state is meaningful
+   *  (e.g. "Photos (1/3)", "Title (2/4 words)"). */
   label: string;
   weight: number;
   present: boolean;
+  /** Longer guidance — used as title/tooltip on chips. */
   hint: string;
 }
 
@@ -48,14 +55,14 @@ export interface ItemLike {
   vintedUrl: string | null;
 }
 
-const FIELD_META: Record<CompletenessField, { label: string; hint: string }> = {
-  brand: { label: "Brand", hint: "Add the brand — buyers search for it" },
-  category: { label: "Category", hint: "Pick a category so it shows up in the right browse" },
-  size: { label: "Size", hint: "Size matters for every clothing search" },
-  description: { label: "Description (40+ chars)", hint: "Aim for a couple of sentences — fit, feel, styling ideas" },
-  photos: { label: "3+ photos", hint: "More angles = more clicks" },
-  title: { label: "Title (4+ words)", hint: "Stuff the title with keywords buyers actually search" },
-  vintedUrl: { label: "Vinted link", hint: "Paste the Vinted URL so you can jump back to the live listing" },
+const STATIC_HINTS: Record<CompletenessField, string> = {
+  brand: "Add the brand — buyers search for it",
+  category: "Pick a category so it shows up in the right browse",
+  size: "Size matters for every clothing search",
+  description: "Aim for a couple of sentences — fit, feel, styling ideas",
+  photos: "More angles = more clicks",
+  title: "Stuff the title with keywords buyers actually search",
+  vintedUrl: "Paste the Vinted URL so you can jump back to the live listing",
 };
 
 function hasText(v: string | null | undefined, minLen = 1): boolean {
@@ -67,38 +74,96 @@ function wordCount(v: string | null | undefined): number {
   return (v as string).trim().split(/\s+/).length;
 }
 
+function photoCountOf(item: ItemLike): number {
+  if (typeof item.photoCount === "number") return item.photoCount;
+  return Array.isArray(item.photoUrls) ? item.photoUrls.length : 0;
+}
+
+function descriptionLength(item: ItemLike): number {
+  return typeof item.description === "string" ? item.description.trim().length : 0;
+}
+
+/** Build a per-field FieldStatus with a label that reflects the *current*
+ *  state of the item — so a chip can read "Photos (1/3)" instead of
+ *  the always-the-same "3+ photos". */
+function buildField(field: CompletenessField, item: ItemLike): FieldStatus {
+  const weight = WEIGHTS[field];
+  const hint = STATIC_HINTS[field];
+
+  switch (field) {
+    case "brand": {
+      const present = hasText(item.brand);
+      return { field, label: "Brand", weight, present, hint };
+    }
+    case "category": {
+      const present = hasText(item.category);
+      return { field, label: "Category", weight, present, hint };
+    }
+    case "size": {
+      const present = hasText(item.size);
+      return { field, label: "Size", weight, present, hint };
+    }
+    case "vintedUrl": {
+      const present = hasText(item.vintedUrl);
+      return { field, label: "Vinted link", weight, present, hint };
+    }
+    case "photos": {
+      const n = photoCountOf(item);
+      const present = n >= PHOTO_TARGET;
+      const label = present
+        ? `Photos (${n})`
+        : n === 0
+          ? `Photos (0/${PHOTO_TARGET})`
+          : `Photos (${n}/${PHOTO_TARGET})`;
+      return { field, label, weight, present, hint };
+    }
+    case "title": {
+      const w = wordCount(item.name);
+      const present = w >= TITLE_TARGET;
+      const label = present
+        ? "Title"
+        : `Title (${w}/${TITLE_TARGET} words)`;
+      return { field, label, weight, present, hint };
+    }
+    case "description": {
+      const len = descriptionLength(item);
+      const present = len >= DESCRIPTION_TARGET;
+      const label = present
+        ? "Description"
+        : len === 0
+          ? `Description (0/${DESCRIPTION_TARGET} chars)`
+          : `Description (${len}/${DESCRIPTION_TARGET} chars)`;
+      return { field, label, weight, present, hint };
+    }
+  }
+}
+
+const ALL_FIELDS: CompletenessField[] = [
+  "brand",
+  "category",
+  "size",
+  "description",
+  "photos",
+  "title",
+  "vintedUrl",
+];
+
 export function scoreItem(item: ItemLike): CompletenessResult {
-  const checks: Array<[CompletenessField, boolean]> = [
-    ["brand", hasText(item.brand)],
-    ["category", hasText(item.category)],
-    ["size", hasText(item.size)],
-    ["description", hasText(item.description, 40)],
-    [
-      "photos",
-      typeof item.photoCount === "number"
-        ? item.photoCount >= 3
-        : Array.isArray(item.photoUrls) && item.photoUrls.length >= 3,
-    ],
-    ["title", wordCount(item.name) >= 4],
-    ["vintedUrl", hasText(item.vintedUrl)],
-  ];
-
-  const fields: FieldStatus[] = checks.map(([field, present]) => ({
-    field,
-    label: FIELD_META[field].label,
-    weight: WEIGHTS[field],
-    present,
-    hint: FIELD_META[field].hint,
-  }));
-
+  const fields = ALL_FIELDS.map((f) => buildField(f, item));
   const score = fields.reduce((sum, f) => sum + (f.present ? f.weight : 0), 0);
   const band: "green" | "amber" | "red" =
     score >= 80 ? "green" : score >= 50 ? "amber" : "red";
   const missing = fields
     .filter((f) => !f.present)
     .sort((a, b) => b.weight - a.weight);
-
   return { score, band, fields, missing };
+}
+
+export interface ItemGap {
+  itemId: string;
+  score: number;
+  /** All missing fields for this item, sorted by weight desc. */
+  missing: FieldStatus[];
 }
 
 export interface CompletenessSummary {
@@ -106,13 +171,9 @@ export interface CompletenessSummary {
   averageScore: number;
   healthyPct: number;
   bands: { green: number; amber: number; red: number };
-  biggestImpact: Array<{
-    itemId: string;
-    score: number;
-    missingField: CompletenessField;
-    missingLabel: string;
-    missingWeight: number;
-  }>;
+  /** Items with the most impactful gaps. Each row carries the full set of
+   *  missing fields so the UI can render every chip, not just the top one. */
+  topGaps: ItemGap[];
 }
 
 export function summarise(
@@ -125,46 +186,34 @@ export function summarise(
       averageScore: 0,
       healthyPct: 0,
       bands: { green: 0, amber: 0, red: 0 },
-      biggestImpact: [],
+      topGaps: [],
     };
   }
 
   const bands = { green: 0, amber: 0, red: 0 };
   let totalScore = 0;
-  const rows: Array<{
-    itemId: string;
-    score: number;
-    biggestGap: FieldStatus | null;
-  }> = [];
+  const rows: ItemGap[] = [];
 
   for (const item of items) {
     const r = scoreItem(item);
     totalScore += r.score;
     bands[r.band]++;
-    rows.push({
-      itemId: item.id,
-      score: r.score,
-      biggestGap: r.missing[0] ?? null,
-    });
+    if (r.missing.length > 0) {
+      rows.push({ itemId: item.id, score: r.score, missing: r.missing });
+    }
   }
 
-  const biggestImpact = rows
-    .filter((r) => r.biggestGap != null)
-    .sort((a, b) => b.biggestGap!.weight - a.biggestGap!.weight || a.score - b.score)
-    .slice(0, limit)
-    .map((r) => ({
-      itemId: r.itemId,
-      score: r.score,
-      missingField: r.biggestGap!.field,
-      missingLabel: r.biggestGap!.label,
-      missingWeight: r.biggestGap!.weight,
-    }));
+  // Rank items by their single biggest gap weight, then by score asc
+  // (lower scores surface first when biggest-gap weights tie).
+  const topGaps = rows
+    .sort((a, b) => (b.missing[0]?.weight ?? 0) - (a.missing[0]?.weight ?? 0) || a.score - b.score)
+    .slice(0, limit);
 
   return {
     count: items.length,
     averageScore: Math.round(totalScore / items.length),
     healthyPct: Math.round((bands.green / items.length) * 100),
     bands,
-    biggestImpact,
+    topGaps,
   };
 }


### PR DESCRIPTION
## Summary
- "Biggest completeness wins" on Health now shows **every** missing-field chip per item, not just the top one. Chips read concretely: `Photos (1/3)`, `Title (2/4 words)`, `Description (15/40 chars)`.
- Each chip deep-links to `/inventory/[id]?focus=<field>` — the item detail page auto-opens its new **Listing details** section and focuses that input.
- Inventory list with `?incomplete=1` swaps the Brand/Size columns for a Missing chip column with the same deep-links.
- Fixes the `incompleteOnly` filter so it actually matches the Health page's score (was checking `condition`/`listedPrice`, neither of which count toward completeness).
- Item detail page gains an editable Listing details section (title, brand, category, size, description, vintedUrl). Live completeness preview as you type.

Closes #58

## Test plan
- [ ] `/health` — Biggest wins card lists multiple chips per item where applicable
- [ ] Click a chip → details section opens with the right input focused
- [ ] Edit a field, save, see the chip drop off when you bounce back to `/health`
- [ ] `/inventory?incomplete=1` — table now shows the Missing column; items that previously appeared incomplete only because of `condition` or `listedPrice` should drop off
- [ ] Health page still fits 1280×800 without page scroll
- [ ] Item detail page still fits 1280×800 with the section closed

## Known follow-ups
- `?focus=photos` opens the section but there's no input there (photos live in the card above) — minor UX gap.
- `incompleteOnly` still does an in-memory post-filter — fine at current inventory sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)