### PR TITLE
Mobile responsiveness pass across main pages (#30)

### DIFF
--- a/src/app/(app)/bestsellers/page.tsx
+++ b/src/app/(app)/bestsellers/page.tsx
@@ -139,7 +139,7 @@ export default async function BestsellersPage({
         title="Best sellers"
         subtitle="What's flying out the door — time-to-sell grouped by product attributes."
         actions={
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <SegmentedControl
               options={TYPE_OPTIONS}
               active={typeFilter}
@@ -148,7 +148,7 @@ export default async function BestsellersPage({
                 buildHref({ preset, dim: dimension, sort: sortKey, type: v })
               }
             />
-          <PresetSelect options={PRESETS} value={preset} />
+            <PresetSelect options={PRESETS} value={preset} />
           </div>
         }
       />

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -100,7 +100,7 @@ export default async function DashboardPage() {
         </section>
       )}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <section className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
         <Tile
           label="Revenue this month"
           value={gbp(month.summary.revenue)}
@@ -162,7 +162,8 @@ export default async function DashboardPage() {
                 .
               </p>
             ) : (
-              <table className="w-full border-collapse text-sm">
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[480px] border-collapse text-sm">
                 <thead>
                   <tr className="border-y border-[var(--border-subtle)] bg-[var(--surface-muted)] text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
                     <th className="py-2 pl-5 pr-3 font-medium">Item</th>
@@ -217,6 +218,7 @@ export default async function DashboardPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             )}
           </Card>
         </div>

--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -217,7 +217,7 @@ export default async function HealthPage() {
                   );
                 })}
               </div>
-              <ul className="mt-4 grid grid-cols-5 gap-2">
+              <ul className="mt-4 grid grid-cols-3 gap-2 sm:grid-cols-5">
                 {BUCKETS.map((b) => {
                   const count = h.aging.buckets[b.key];
                   return (

--- a/src/app/(app)/inventory/page.tsx
+++ b/src/app/(app)/inventory/page.tsx
@@ -240,8 +240,8 @@ function TableView({
 }) {
   return (
     <Card padded={false} className="overflow-visible">
-      <div>
-        <table className="w-full border-collapse text-sm">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[760px] border-collapse text-sm">
           <thead>
             <tr className="border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]/40 text-left text-[11px] uppercase tracking-wide text-[var(--text-muted)]">
               <th className="w-16 py-3 pl-4 pr-2 font-medium">Thumbnail</th>

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -203,7 +203,7 @@ export default async function ProfitPage({
         title="Profit"
         subtitle={formatRangeSubtitle(range.from, range.to)}
         actions={
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <SegmentedControl
               options={TYPE_OPTIONS}
               active={p.type}

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -58,7 +58,7 @@ export default async function MarketingPage() {
         </div>
 
         {/* Animated dashboard preview */}
-        <div className="relative">
+        <div className="relative w-full max-w-full overflow-hidden">
           <div className="absolute -inset-6 -z-10 rounded-[28px] bg-[var(--surface-muted)]/60 blur-2xl" />
           <AnimatedDashboard />
         </div>


### PR DESCRIPTION
## Summary
First pass on issue #30 — targeted mobile fixes across Dashboard, Inventory, Profit, Health, Bestsellers, and Marketing.

- **Dashboard**: tile grid is 2×2 on phones (was 1-col, now matches the brief), and the top-profit table gets a scroll-x wrapper with a min-width so columns stay legible
- **Inventory**: table view wrapped in scroll-x with `min-w-[760px]` — grid view was already responsive (2/3/4/5 cols)
- **Profit**: `PageHeader` filter actions (type segment + preset select) wrap on narrow widths instead of overflowing
- **Health**: aging buckets legend goes from a fixed 5-col grid (overflowed labels on phones) to 3-col on mobile, 5-col at `sm`+
- **Bestsellers**: same `flex-wrap` fix for filter actions
- **Marketing**: AnimatedDashboard preview clamped with `max-w-full overflow-hidden` so the absolutely-positioned blur halo can't extend the viewport

Bottom-tab nav and top-nav collapse were already in place from earlier work, so this PR is purely tile/grid/table widths.

Item detail and inventory grid view were already responsive, so no changes there. The brief calls for the item detail primary action to stick to the bottom of the viewport on mobile — skipped for now because the existing popover dropdown logic would need a non-trivial refactor to flip direction. Worth a follow-up issue if Calvin wants it.

## Test plan
- [ ] Visit `/dashboard` at 390 wide — tiles render 2×2, top-profit table scrolls horizontally
- [ ] Visit `/inventory` (table view) at 390 wide — table scrolls without breaking out of the card
- [ ] Visit `/profit` and `/bestsellers` at 390 wide — filter chips wrap below the title instead of overflowing
- [ ] Visit `/health` at 390 wide — aging legend shows 3 columns, no clipped labels
- [ ] Visit `/` (marketing) at 390 wide — hero/feature cards stack cleanly, no horizontal scroll
- [ ] Verify desktop (1280×800) still passes the no-scroll rule on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)