### PR TITLE
Aurora visual refresh: dark tokens, Geist, landing rebuild, Clerk theming

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^7.2.9",
+    "@clerk/themes": "^2.4.57",
     "@neondatabase/serverless": "^1.1.0",
     "@vercel/blob": "^2.3.3",
     "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@neondatabase/serverless": "^1.1.0",
     "@vercel/blob": "^2.3.3",
     "drizzle-orm": "^0.45.2",
+    "geist": "^1.7.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@clerk/nextjs':
         specifier: ^7.2.9
         version: 7.2.9(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/themes':
+        specifier: ^2.4.57
+        version: 2.4.57(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
@@ -165,6 +168,18 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
+  '@clerk/shared@3.47.5':
+    resolution: {integrity: sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   '@clerk/shared@4.8.7':
     resolution: {integrity: sha512-rnQnsYy4Rb4WPEmVCF4CLmIn1359SP17IAH7fDqWc3agaOcEaP/iQPSxmC9PMuzVBA7S+LtfO/dGH2dLOczsTQ==}
     engines: {node: '>=20.9.0'}
@@ -176,6 +191,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@clerk/themes@2.4.57':
+    resolution: {integrity: sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w==}
+    engines: {node: '>=18.17.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1445,6 +1464,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2682,6 +2704,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -2956,6 +2983,18 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
 
+  '@clerk/shared@3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@clerk/shared@4.8.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.100.7
@@ -2966,6 +3005,14 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@clerk/themes@2.4.57(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -3927,6 +3974,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -5318,6 +5367,12 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swr@2.3.4(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   tailwindcss@4.2.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)
+      geist:
+        specifier: ^1.7.0
+        version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1907,6 +1910,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  geist@1.7.0:
+    resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -4500,6 +4508,10 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   generator-function@2.0.1: {}
 

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -8,154 +8,233 @@ export default async function MarketingPage() {
   const { userId } = await auth();
 
   return (
-    <main className="min-h-dvh bg-[var(--surface-canvas)]">
-      {/* Top brand row */}
-      <header className="mx-auto flex max-w-6xl items-start justify-between px-6 pt-8">
-        <span className="font-display text-2xl tracking-tight text-[var(--text-primary)]">
-          Relist
-        </span>
-        <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)] sm:inline">
-          Good times, better profit
-        </span>
+    <main className="aurora-ambient flex min-h-dvh flex-col bg-[var(--surface-canvas)] text-[var(--text-primary)] lg:h-dvh lg:overflow-hidden">
+      {/* Top nav */}
+      <header className="mx-auto flex w-full max-w-6xl shrink-0 items-center justify-between px-6 pt-5">
+        <div className="flex items-center gap-3">
+          <span className="bg-brand-gradient grid h-8 w-8 place-items-center rounded-[9px] font-bold text-[var(--text-inverse)] shadow-brand-glow">
+            R
+          </span>
+          <span className="text-[17px] font-semibold tracking-tight">Relist</span>
+          <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)] sm:inline">
+            good times, better profit
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {userId ? (
+            <>
+              <ButtonLink href="/dashboard" size="sm">
+                Open dashboard
+              </ButtonLink>
+              <UserButton />
+            </>
+          ) : (
+            <div className="[&_button]:bg-brand-gradient [&_button]:text-[var(--text-inverse)] [&_button]:shadow-brand-glow [&_button]:inline-flex [&_button]:h-9 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-[var(--radius-md)] [&_button]:px-4 [&_button]:text-[13px] [&_button]:font-semibold [&_button]:cursor-pointer [&_button:hover]:brightness-110">
+              <SignInButton mode="modal">
+                <button>Sign in</button>
+              </SignInButton>
+            </div>
+          )}
+        </div>
       </header>
 
-      {/* Hero */}
-      <section className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-12 px-6 pt-12 pb-20 lg:grid-cols-[1.05fr_1fr] lg:gap-16 lg:pt-16">
+      {/* Hero — fills remaining viewport on desktop */}
+      <section className="mx-auto grid w-full max-w-6xl grid-cols-1 items-center gap-10 px-6 py-8 lg:min-h-0 lg:flex-1 lg:grid-cols-[1.05fr_1fr] lg:gap-14 lg:py-6">
         <div className="max-w-xl">
-          <h1 className="font-display text-[clamp(4rem,11vw,8rem)] font-medium leading-[0.92] tracking-tight text-[var(--text-primary)]">
-            Relist
+          {/* Eyebrow */}
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[var(--border-default)] bg-[var(--surface-glass)] py-1 pl-1 pr-3 text-[11px] font-medium text-[var(--text-secondary)] backdrop-blur-sm">
+            <span className="bg-brand-gradient rounded-full px-2 py-[2px] font-mono text-[10px] font-bold tracking-wide text-[var(--text-inverse)]">
+              v2
+            </span>
+            Built for Vinted sellers · invite-only
+          </div>
+
+          {/* Headline */}
+          <h1 className="font-display text-[clamp(3rem,7.5vw,5.5rem)] font-bold leading-[0.95] tracking-tight">
+            <span
+              className="bg-clip-text text-transparent"
+              style={{
+                backgroundImage:
+                  "linear-gradient(180deg, var(--text-primary) 0%, #8c95a8 130%)",
+              }}
+            >
+              Resale,
+            </span>
+            <br />
+            <span className="text-brand-gradient italic">sorted.</span>
           </h1>
-          <p className="mt-6 max-w-md text-lg leading-relaxed text-[var(--text-secondary)]">
-            Track your resale inventory, prices, and profits across{" "}
-            <span className="text-[var(--brand)]">Vinted</span> and beyond.
+
+          <p className="mt-5 max-w-md text-[15px] leading-relaxed text-[var(--text-secondary)]">
+            Track your inventory, prices, and profits across{" "}
+            <span className="font-medium text-[var(--brand)]">Vinted</span> — without
+            spreadsheet wrangling. Photos, margins, and what to ship today, in one
+            quiet place.
           </p>
 
-          <div className="mt-10">
+          {/* CTA */}
+          <div className="mt-6 flex flex-wrap items-center gap-4">
             {userId ? (
               <div className="flex items-center gap-3">
                 <ButtonLink href="/dashboard" size="md">
-                  Open dashboard
+                  Open dashboard →
                 </ButtonLink>
                 <UserButton />
               </div>
             ) : (
-              <div className="space-y-4">
-                <div className="[&_button]:inline-flex [&_button]:h-10 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-[var(--radius-md)] [&_button]:bg-[var(--brand)] [&_button]:px-5 [&_button]:text-sm [&_button]:font-medium [&_button]:text-white [&_button]:transition-colors [&_button:hover]:bg-[var(--brand-hover)] [&_button]:cursor-pointer">
-                  <SignInButton mode="modal">
-                    <button>Sign in</button>
-                  </SignInButton>
-                </div>
-                <p className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
-                  <span
-                    aria-hidden
-                    className="inline-block h-1 w-1 rounded-full bg-[var(--text-muted)]"
-                  />
-                  Access is invite-only. Ask Calvin for an invite link.
-                </p>
+              <div className="[&_button]:bg-brand-gradient [&_button]:text-[var(--text-inverse)] [&_button]:shadow-brand-glow [&_button]:inline-flex [&_button]:h-11 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-[var(--radius-md)] [&_button]:px-6 [&_button]:text-sm [&_button]:font-semibold [&_button]:cursor-pointer [&_button:hover]:brightness-110">
+                <SignInButton mode="modal">
+                  <button>Sign in →</button>
+                </SignInButton>
               </div>
             )}
+            <p className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+              <span
+                aria-hidden
+                className="relative inline-block h-1.5 w-1.5 rounded-full bg-[var(--money-positive)]"
+                style={{ boxShadow: "0 0 0 3px rgba(52, 211, 153, 0.18)" }}
+              />
+              Access is invite-only · ask Calvin
+            </p>
           </div>
+
+          {/* Trust strip */}
+          <dl className="mt-6 grid grid-cols-3 gap-6 border-t border-[var(--border-subtle)] pt-4">
+            <TrustStat value="Vinted" label="Only platform" />
+            <TrustStat value="£0" label="Vinted fees · ever" />
+            <TrustStat value="Yours" label="Your data, your keys" />
+          </dl>
         </div>
 
-        {/* Animated dashboard preview */}
-        <div className="relative w-full max-w-full overflow-hidden">
-          <div className="absolute -inset-6 -z-10 rounded-[28px] bg-[var(--surface-muted)]/60 blur-2xl" />
+        {/* Animated dashboard preview, with teal ambient glow */}
+        <div className="relative w-full max-w-full">
+          <div
+            aria-hidden
+            className="absolute -inset-8 -z-10 rounded-[28px]"
+            style={{
+              background:
+                "radial-gradient(ellipse, rgba(94,234,212,0.18), transparent 60%)",
+              filter: "blur(20px)",
+            }}
+          />
           <AnimatedDashboard />
         </div>
       </section>
 
-      {/* Feature section */}
-      <section className="mx-auto max-w-6xl px-6 pb-24">
-        <div className="grid grid-cols-1 gap-10 border-t border-[var(--border-subtle)] pt-12 md:grid-cols-[auto_1fr] md:gap-16">
-          <div className="max-w-sm">
-            <span
-              aria-hidden
-              className="inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--surface-inset)] text-[var(--text-muted)]"
-            >
-              {/* tag icon */}
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M20.59 13.41 13.42 20.58a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82Z" />
-                <circle cx="7" cy="7" r="1.4" />
-              </svg>
-            </span>
-            <h2 className="mt-4 font-display text-3xl tracking-tight text-[var(--text-primary)]">
-              Everything in one place
-            </h2>
-            <p className="mt-3 text-sm leading-relaxed text-[var(--text-secondary)]">
-              From thrift finds to sold items, keep every detail organised and
-              know exactly what you&apos;re making.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-            <FeatureCard
-              swatch="emerald"
-              title="Inventory at a glance"
-              body="Photos, prices, and status from sourced through sold — searchable and sortable."
-            />
-            <FeatureCard
-              swatch="rose"
-              title="Profit, not guesses"
-              body="Sale price minus shipping and expenses. Vinted charges sellers nothing, and we don't pretend otherwise."
-            />
-            <FeatureCard
-              swatch="brand"
-              title="Trends you can read"
-              body="Sparklines and deltas show what's working week over week, without spreadsheet wrangling."
-            />
-          </div>
+      {/* Features — compact strip above footer */}
+      <section className="mx-auto w-full max-w-6xl shrink-0 border-t border-[var(--border-subtle)] px-6 py-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <FeatureCard
+            tone="brand"
+            icon={<RectIcon />}
+            title="Inventory at a glance"
+            body="Photos, prices, status from sourced → sold. Searchable, sortable, with thumbnails on Vercel Blob."
+          />
+          <FeatureCard
+            tone="emerald"
+            icon={<TrendIcon />}
+            title="Profit, not guesses"
+            body="Sale price minus shipping and expenses. Vinted charges nothing, and we don't pretend otherwise."
+          />
+          <FeatureCard
+            tone="violet"
+            icon={<ClockIcon />}
+            title="What to do today"
+            body="Ship, refresh, reprice, photograph — your Plan tells you the next four moves before the kettle's boiled."
+          />
         </div>
       </section>
 
-      <footer className="border-t border-[var(--border-subtle)]">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6 text-xs text-[var(--text-muted)]">
-          <span>Relist · resale, sorted.</span>
-          <Link href="/sign-in" className="hover:text-[var(--text-primary)]">
-            Sign in
-          </Link>
+      {/* Footer */}
+      <footer className="shrink-0 border-t border-[var(--border-subtle)]">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-3 text-[11px] text-[var(--text-muted)]">
+          <span>Relist · resale, sorted</span>
+          <span className="font-mono">relist-saas.warmwetcircles.com</span>
         </div>
       </footer>
     </main>
   );
 }
 
+function TrustStat({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <dt className="text-[18px] font-bold tabular-nums tracking-tight text-[var(--text-primary)]">
+        {value}
+      </dt>
+      <dd className="text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        {label}
+      </dd>
+    </div>
+  );
+}
+
+type FeatureTone = "brand" | "emerald" | "violet";
+const FEATURE_TONE: Record<FeatureTone, string> = {
+  brand: "bg-[var(--brand-soft)] text-[var(--brand-soft-fg)]",
+  emerald: "bg-[var(--accent-emerald-soft)] text-[var(--accent-emerald-soft-fg)]",
+  violet: "bg-[var(--accent-violet-soft)] text-[var(--accent-violet-soft-fg)]",
+};
+
 function FeatureCard({
-  swatch,
+  tone,
+  icon,
   title,
   body,
 }: {
-  swatch: "emerald" | "rose" | "brand";
+  tone: FeatureTone;
+  icon: React.ReactNode;
   title: string;
   body: string;
 }) {
-  const swatchBg: Record<typeof swatch, string> = {
-    emerald:
-      "bg-gradient-to-br from-[var(--accent-emerald-soft)] to-[var(--surface-muted)]",
-    rose: "bg-gradient-to-br from-[var(--accent-rose-soft)] to-[var(--surface-muted)]",
-    brand:
-      "bg-gradient-to-br from-[var(--brand-soft)] to-[var(--surface-muted)]",
-  };
-
   return (
-    <article className="overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-1)]">
-      <div className={`aspect-[4/3] w-full ${swatchBg[swatch]}`} aria-hidden />
-      <div className="p-4">
-        <h3 className="font-display text-lg tracking-tight text-[var(--text-primary)]">
+    <article className="surface-glass flex items-start gap-3 rounded-[var(--radius-lg)] p-3.5">
+      <span
+        className={`mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] ${FEATURE_TONE[tone]}`}
+      >
+        {icon}
+      </span>
+      <div className="min-w-0">
+        <h3 className="text-[13px] font-semibold tracking-tight text-[var(--text-primary)]">
           {title}
         </h3>
-        <p className="mt-2 text-xs leading-relaxed text-[var(--text-secondary)]">
+        <p className="mt-1 text-[11.5px] leading-snug text-[var(--text-secondary)]">
           {body}
         </p>
       </div>
     </article>
+  );
+}
+
+/* ----- icons ----- */
+
+function RectIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M2.5 6.5h11M6 2.5v11" stroke="currentColor" strokeWidth="1.3" />
+    </svg>
+  );
+}
+
+function TrendIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        d="M2 12l4-4 3 3 5-6M10 5h4v4"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ClockIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.4" />
+      <path d="M8 2.5v5l3 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,58 +1,66 @@
 @import "tailwindcss";
 
 /* ---------------------------------------------------------------
-   Relist design tokens — see src/components/ui/README.md
+   Relist · Aurora design tokens — dark, glass, gradient-accented.
+   See src/components/ui/README.md for primitive documentation.
    --------------------------------------------------------------- */
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 
-  /* Surfaces */
-  --surface-canvas: #faf7f2;       /* warm cream — page background */
-  --surface-card: #ffffff;         /* card / tile surface */
-  --surface-muted: #f5f2ec;        /* tinted muted surface */
-  --surface-inset: #f1ede5;        /* inputs, sub-cards */
+  /* Surfaces — dark base, glass-friendly */
+  --surface-canvas: #07080b;       /* app/page background */
+  --surface-card: #0d0f14;         /* solid card / tile surface */
+  --surface-muted: #0b0d12;        /* secondary surface */
+  --surface-inset: #101319;        /* inputs, sub-cards */
+  --surface-glass: rgba(255, 255, 255, 0.04); /* over-canvas glass */
+  --surface-glass-2: rgba(255, 255, 255, 0.07); /* raised glass */
 
   /* Foreground */
-  --text-primary: #111827;         /* slate-900 */
-  --text-secondary: #4b5563;       /* slate-600 */
-  --text-muted: #6b7280;           /* slate-500 */
-  --text-inverse: #ffffff;
+  --text-primary: #f4f5f8;
+  --text-secondary: #a1a8b8;
+  --text-muted: #6b7384;
+  --text-faint: #4b5263;
+  --text-inverse: #0a0a0a;          /* on gradient/light buttons */
 
-  /* Borders */
-  --border-subtle: #e7e2d8;
-  --border-default: #d6cfc1;
-  --border-strong: #b8af9a;
+  /* Borders — translucent so they sit nicely on any surface */
+  --border-subtle: rgba(255, 255, 255, 0.07);
+  --border-default: rgba(255, 255, 255, 0.12);
+  --border-strong: rgba(255, 255, 255, 0.20);
 
-  /* Brand / accents */
-  --brand: #0f766e;                /* teal 700 — primary */
-  --brand-hover: #115e59;
-  --brand-soft: #ccfbf1;
-  --brand-soft-fg: #134e4a;
+  /* Brand — teal → indigo gradient is the signature accent */
+  --brand: #5eead4;
+  --brand-hover: #7ff3df;
+  --brand-2: #818cf8;
+  --brand-gradient: linear-gradient(135deg, #5eead4 0%, #818cf8 100%);
+  --brand-glow: 0 6px 20px rgba(94, 234, 212, 0.25);
+  --brand-soft: rgba(94, 234, 212, 0.16);
+  --brand-soft-fg: #5eead4;
 
-  --accent-amber: #f59e0b;
-  --accent-amber-soft: #fef3c7;
-  --accent-amber-soft-fg: #78350f;
+  /* Accents — saturated for dark, soft variants are translucent tints */
+  --accent-amber: #fbbf24;
+  --accent-amber-soft: rgba(251, 191, 36, 0.16);
+  --accent-amber-soft-fg: #fbbf24;
 
-  --accent-violet: #7c3aed;
-  --accent-violet-soft: #ede9fe;
-  --accent-violet-soft-fg: #4c1d95;
+  --accent-violet: #a78bfa;
+  --accent-violet-soft: rgba(167, 139, 250, 0.16);
+  --accent-violet-soft-fg: #a78bfa;
 
-  --accent-rose: #f43f5e;
-  --accent-rose-soft: #ffe4e6;
-  --accent-rose-soft-fg: #9f1239;
+  --accent-rose: #fb7185;
+  --accent-rose-soft: rgba(251, 113, 133, 0.14);
+  --accent-rose-soft-fg: #fb7185;
 
-  --accent-emerald: #059669;
-  --accent-emerald-soft: #d1fae5;
-  --accent-emerald-soft-fg: #064e3b;
+  --accent-emerald: #34d399;
+  --accent-emerald-soft: rgba(52, 211, 153, 0.14);
+  --accent-emerald-soft-fg: #34d399;
 
-  --accent-blue: #2563eb;
-  --accent-blue-soft: #dbeafe;
-  --accent-blue-soft-fg: #1e3a8a;
+  --accent-blue: #60a5fa;
+  --accent-blue-soft: rgba(96, 165, 250, 0.14);
+  --accent-blue-soft-fg: #60a5fa;
 
-  --accent-slate: #475569;
-  --accent-slate-soft: #e2e8f0;
-  --accent-slate-soft-fg: #1e293b;
+  --accent-slate: #94a3b8;
+  --accent-slate-soft: rgba(148, 163, 184, 0.12);
+  --accent-slate-soft-fg: #cbd5e1;
 
   /* Money semantic */
   --money-positive: var(--accent-emerald);
@@ -60,14 +68,14 @@
 
   /* Radii */
   --radius-sm: 6px;
-  --radius-md: 10px;
+  --radius-md: 9px;
   --radius-lg: 14px;
-  --radius-xl: 20px;
+  --radius-xl: 18px;
 
-  /* Elevation */
-  --elev-1: 0 1px 2px rgba(15, 23, 42, 0.04), 0 1px 1px rgba(15, 23, 42, 0.03);
-  --elev-2: 0 4px 12px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
-  --elev-3: 0 12px 32px rgba(15, 23, 42, 0.10), 0 4px 8px rgba(15, 23, 42, 0.04);
+  /* Elevation — soft, dark-friendly drop shadows */
+  --elev-1: 0 1px 2px rgba(0, 0, 0, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  --elev-2: 0 8px 24px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  --elev-3: 0 30px 60px rgba(0, 0, 0, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 @theme inline {
@@ -117,8 +125,9 @@
   --color-money-positive: var(--money-positive);
   --color-money-negative: var(--money-negative);
 
-  --font-sans: var(--font-inter);
-  --font-display: var(--font-fraunces);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-geist-sans);
 }
 
 @layer base {
@@ -132,27 +141,86 @@
   }
 
   body {
-    font-family: var(--font-inter), system-ui, sans-serif;
+    font-family: var(--font-geist-sans), system-ui, sans-serif;
     -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    letter-spacing: -0.005em;
   }
 
   input, select, textarea {
-    background: var(--surface-card);
+    background: var(--surface-inset);
     color: var(--text-primary);
     border-color: var(--border-default);
   }
 
+  input::placeholder, textarea::placeholder { color: var(--text-faint); }
+
   input:focus, select:focus, textarea:focus {
-    outline: 2px solid var(--brand);
-    outline-offset: 1px;
+    outline: none;
+    border-color: var(--brand);
+    box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.18);
   }
 
   button {
     cursor: pointer;
   }
 
+  /* Display class — was Fraunces serif; now Geist with display weight + tight tracking. */
   .font-display {
-    font-family: var(--font-fraunces), Georgia, serif;
-    font-optical-sizing: auto;
+    font-family: var(--font-geist-sans), system-ui, sans-serif;
+    font-weight: 700;
+    letter-spacing: -0.025em;
   }
+
+  /* tabular numerics by default for headline numbers */
+  .tabular-nums { font-variant-numeric: tabular-nums; }
+}
+
+/* ---------------------------------------------------------------
+   Utilities — Aurora-specific reusable bits
+   --------------------------------------------------------------- */
+
+@layer utilities {
+  /* Brand gradient applied as a background */
+  .bg-brand-gradient {
+    background-image: var(--brand-gradient);
+  }
+
+  /* Brand gradient text-clipped */
+  .text-brand-gradient {
+    background-image: var(--brand-gradient);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  /* Soft glow under brand surfaces */
+  .shadow-brand-glow {
+    box-shadow: var(--brand-glow);
+  }
+
+  /* Glass surface (over the canvas/ambient gradients) */
+  .surface-glass {
+    background: var(--surface-glass);
+    border: 1px solid var(--border-subtle);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
+
+  /* Ambient aurora — apply to a positioned ::before on full-screen surfaces */
+  .aurora-ambient {
+    position: relative;
+  }
+  .aurora-ambient::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background:
+      radial-gradient(ellipse 700px 380px at 10% -8%, rgba(94, 234, 212, 0.16), transparent 55%),
+      radial-gradient(ellipse 600px 380px at 100% 5%, rgba(167, 139, 250, 0.14), transparent 55%),
+      radial-gradient(ellipse 900px 500px at 60% 110%, rgba(129, 140, 248, 0.07), transparent 60%);
+  }
+  .aurora-ambient > * { position: relative; z-index: 1; }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,8 @@
 import type { Metadata } from "next";
-import { Inter, Fraunces } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
-
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-  display: "swap",
-});
-
-const fraunces = Fraunces({
-  variable: "--font-fraunces",
-  subsets: ["latin"],
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Relist",
@@ -29,7 +18,7 @@ export default function RootLayout({
     <ClerkProvider>
       <html
         lang="en"
-        className={`${inter.variable} ${fraunces.variable} h-full antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} h-full antialiased`}
       >
         <body className="min-h-full flex flex-col">{children}</body>
       </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { ClerkProvider } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -15,7 +16,36 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider>
+    <ClerkProvider
+      appearance={{
+        baseTheme: dark,
+        variables: {
+          colorPrimary: "#5eead4",
+          colorBackground: "#0d0f14",
+          colorText: "#f4f5f8",
+          colorTextSecondary: "#a1a8b8",
+          colorInputBackground: "#101319",
+          colorInputText: "#f4f5f8",
+          colorNeutral: "#f4f5f8",
+          borderRadius: "9px",
+          fontFamily: "var(--font-geist-sans), system-ui, sans-serif",
+        },
+        elements: {
+          card: "shadow-2xl border border-white/10 bg-[#0d0f14]/95 backdrop-blur-xl",
+          headerTitle: "tracking-tight",
+          formButtonPrimary:
+            "bg-gradient-to-br from-[#5eead4] to-[#818cf8] text-[#0a0a0a] font-semibold shadow-[0_6px_20px_rgba(94,234,212,0.25)] hover:brightness-110 normal-case",
+          socialButtonsBlockButton:
+            "border border-white/10 bg-white/[0.07] hover:bg-white/[0.10] text-[#f4f5f8]",
+          footerActionLink: "text-[#5eead4] hover:text-[#7ff3df]",
+          formFieldInput:
+            "bg-[#101319] border border-white/10 text-[#f4f5f8] focus:border-[#5eead4]",
+          identityPreviewEditButton: "text-[#5eead4]",
+          dividerLine: "bg-white/10",
+          dividerText: "text-[#6b7384]",
+        },
+      }}
+    >
       <html
         lang="en"
         className={`${GeistSans.variable} ${GeistMono.variable} h-full antialiased`}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,13 +6,13 @@ type Size = "sm" | "md";
 
 const VARIANT: Record<Variant, string> = {
   primary:
-    "bg-[var(--brand)] text-white hover:bg-[var(--brand-hover)] border border-transparent",
+    "bg-brand-gradient text-[var(--text-inverse)] shadow-brand-glow font-semibold border-0 hover:brightness-105",
   secondary:
-    "bg-[var(--surface-card)] text-[var(--text-primary)] border border-[var(--border-default)] hover:bg-[var(--surface-muted)]",
+    "bg-[var(--surface-glass-2)] text-[var(--text-primary)] border border-[var(--border-default)] hover:bg-[var(--surface-inset)] backdrop-blur-sm",
   ghost:
-    "bg-transparent text-[var(--text-primary)] border border-transparent hover:bg-[var(--surface-muted)]",
+    "bg-transparent text-[var(--text-primary)] border border-transparent hover:bg-[var(--surface-glass)]",
   destructive:
-    "bg-[var(--accent-rose)] text-white hover:opacity-90 border border-transparent",
+    "bg-[var(--accent-rose)] text-[var(--text-inverse)] hover:opacity-90 border border-transparent",
 };
 
 const SIZE: Record<Size, string> = {


### PR DESCRIPTION
## Summary

Visual refresh for the public-facing surfaces ahead of sharing relist-saas with the first family member. Establishes the Aurora design language across tokens, the landing page, and the Clerk sign-in modal.

- **Tokens**: flip \`globals.css\` from warm cream / teal / Fraunces to dark canvas / brand-gradient / Geist. Add utilities for the brand gradient, gradient text-clip, glass surfaces, and ambient aurora.
- **Type**: replace Fraunces + Inter with Geist Sans + Geist Mono via the \`geist\` package. \`.font-display\` now maps to Geist 700 / tight tracking, so existing call-sites keep working.
- **Button**: primary variant uses the brand gradient + glow + dark text.
- **Landing**: rebuilt \`(marketing)/page.tsx\` — gradient-clipped headline ("Resale, *sorted.*"), eyebrow pill, invite-only pulse note, three-stat trust strip, three horizontal glass feature cards, teal halo behind the (existing) AnimatedDashboard. Fits 1280 × 800 with no desktop scroll (lg:h-dvh + lg:overflow-hidden); mobile keeps natural scroll per the desktop-only no-scroll rule.
- **Clerk modal**: themed via \`ClerkProvider\` appearance — dark \`baseTheme\`, Aurora variables (teal primary, dark surfaces, Geist), element overrides giving the submit button the brand gradient and the card glass chrome.

Existing app pages (Dashboard, Inventory, Profit, Health, etc.) inherit the dark token flip automatically and will be polished page-by-page in a follow-up PR — they're functional and on-brand-color right now, just not yet Aurora-rebuilt.

## Test plan

- [ ] \`pnpm build\` passes locally (verified)
- [ ] Landing renders at relist-saas.warmwetcircles.com after Vercel deploy
- [ ] Sign-in modal opens, shows Aurora theming, sign-in completes, lands on dashboard
- [ ] Landing fits 1280 × 800 with no vertical scroll
- [ ] Mobile widths render with natural scroll, nothing clipped
- [ ] tenancy-check workflow still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)