### PR TITLE
Onboarding quick wins for first invited user (refs #64)

### DIFF
--- a/src/app/(app)/bestsellers/page.tsx
+++ b/src/app/(app)/bestsellers/page.tsx
@@ -134,7 +134,7 @@ export default async function BestsellersPage({
   const hasEnough = data.overall.totalSold >= data.minGroupSize;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <PageHeader
         title="Best sellers"
         subtitle="What's flying out the door — time-to-sell grouped by product attributes."

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -72,7 +72,7 @@ export default async function DashboardPage() {
   });
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <PageHeader
         title="Dashboard"
         subtitle={now.toLocaleString("en-GB", { month: "long", year: "numeric" })}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -85,14 +85,14 @@ export default async function DashboardPage() {
       />
 
       {sampleLoaded && (
-        <section className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-md)] border border-[var(--accent-amber)]/30 bg-[var(--accent-amber-soft)] px-4 py-3 text-sm text-[var(--accent-amber-soft-fg)]">
+        <section className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-md)] border border-[var(--accent-amber)]/30 bg-[var(--accent-amber-soft)] px-3.5 py-2 text-[13px] text-[var(--accent-amber-soft-fg)]">
           <span>
             Sample data is loaded in your account. Clear it once you&apos;re ready to work with real items only.
           </span>
           <form action={clearSampleDataAction}>
             <button
               type="submit"
-              className="rounded-[var(--radius-md)] border border-[var(--accent-amber)]/40 bg-white px-3 py-1.5 text-xs font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--surface-muted)]"
+              className="rounded-[var(--radius-md)] border border-[var(--accent-amber)]/40 bg-[var(--surface-card)] px-3 py-1 text-[12px] font-medium text-[var(--accent-amber-soft-fg)] hover:bg-[var(--surface-muted)]"
             >
               Clear sample data
             </button>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -100,6 +100,10 @@ export default async function DashboardPage() {
         </section>
       )}
 
+      {isFirstRun ? (
+        <FirstRunNudge variant="panel" />
+      ) : (
+        <>
       <section className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
         <Tile
           label="Revenue this month"
@@ -224,21 +228,19 @@ export default async function DashboardPage() {
         </div>
 
         <div>
-          {isFirstRun ? (
-            <FirstRunNudge variant="panel" />
-          ) : (
-            <Card>
-              <CardHeader title="Quick actions" description="The fast path to common tasks." />
-              <ul className="mt-4 space-y-2 text-sm">
-                <ActionRow href="/inventory/new" label="Add a new item" />
-                <ActionRow href="/plan" label="See today's plan" />
-                <ActionRow href="/inventory?status=listed" label="Browse listed items" />
-                <ActionRow href="/expenses" label="Log an expense" />
-              </ul>
-            </Card>
-          )}
+          <Card>
+            <CardHeader title="Quick actions" description="The fast path to common tasks." />
+            <ul className="mt-4 space-y-2 text-sm">
+              <ActionRow href="/inventory/new" label="Add a new item" />
+              <ActionRow href="/plan" label="See today's plan" />
+              <ActionRow href="/inventory?status=listed" label="Browse listed items" />
+              <ActionRow href="/expenses" label="Log an expense" />
+            </ul>
+          </Card>
         </div>
       </section>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -106,7 +106,7 @@ export default async function HealthPage() {
   const paceTone = PACE_TONE[h.cadence.paceBand];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <PageHeader
         title="Inventory health"
         subtitle="A weekly pulse on the quality, freshness and value of your live stock."

--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -123,13 +123,14 @@ export default async function HealthPage() {
         }
       />
 
-      {isFirstRun && (
+      {isFirstRun ? (
         <FirstRunNudge
+          variant="panel"
           heading="Nothing to score yet"
           body="Health metrics need active listings. Add an item and check back."
         />
-      )}
-
+      ) : (
+        <>
       {/* Headline tiles */}
       <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Tile
@@ -444,6 +445,8 @@ export default async function HealthPage() {
           )}
         </Card>
       </section>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(app)/inventory/new/form.tsx
+++ b/src/app/(app)/inventory/new/form.tsx
@@ -5,6 +5,9 @@ import { useRouter } from "next/navigation";
 
 type AcquisitionType = "bought" | "own";
 
+const INPUT_CLASS =
+  "w-full rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--brand)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-soft)]";
+
 export function NewItemForm() {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -69,7 +72,7 @@ export function NewItemForm() {
   return (
     <form onSubmit={submit} className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="md:col-span-2">
-        <span className="text-xs uppercase text-gray-500">
+        <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
           Where did this come from?
         </span>
         <div
@@ -102,7 +105,7 @@ export function NewItemForm() {
             );
           })}
         </div>
-        <p className="mt-1 text-[11px] text-gray-500">
+        <p className="mt-1 text-[11px] text-[var(--text-muted)]">
           {acquisitionType === "own"
             ? "Already yours — we treat the cost as £0."
             : "Sourced for resale — record what you paid."}
@@ -114,35 +117,35 @@ export function NewItemForm() {
           required
           value={form.name}
           onChange={(e) => set("name", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Brand">
         <input
           value={form.brand}
           onChange={(e) => set("brand", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Category">
         <input
           value={form.category}
           onChange={(e) => set("category", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Size">
         <input
           value={form.size}
           onChange={(e) => set("size", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Condition">
         <select
           value={form.condition}
           onChange={(e) => set("condition", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         >
           {["new", "like_new", "good", "fair"].map((c) => (
             <option key={c} value={c}>
@@ -158,7 +161,7 @@ export function NewItemForm() {
             step="0.01"
             value={form.costPrice}
             onChange={(e) => set("costPrice", e.target.value)}
-            className="w-full rounded-md border px-3 py-2 text-sm"
+            className={INPUT_CLASS}
           />
         </Field>
       )}
@@ -168,7 +171,7 @@ export function NewItemForm() {
           step="0.01"
           value={form.listedPrice}
           onChange={(e) => set("listedPrice", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Status">
@@ -177,7 +180,7 @@ export function NewItemForm() {
           onChange={(e) =>
             set("status", e.target.value as typeof form.status)
           }
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         >
           {["sourced", "listed", "sold", "shipped"].map((s) => (
             <option key={s} value={s}>
@@ -191,7 +194,7 @@ export function NewItemForm() {
           type="url"
           value={form.vintedUrl}
           onChange={(e) => set("vintedUrl", e.target.value)}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
       <Field label="Description" full>
@@ -199,16 +202,20 @@ export function NewItemForm() {
           value={form.description}
           onChange={(e) => set("description", e.target.value)}
           rows={3}
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className={INPUT_CLASS}
         />
       </Field>
 
-      {error && <div className="md:col-span-2 text-sm text-red-600">{error}</div>}
+      {error && (
+        <div className="md:col-span-2 rounded-[var(--radius-md)] border border-[var(--accent-rose-soft)] bg-[var(--accent-rose-soft)] px-3 py-2 text-sm text-[var(--accent-rose-soft-fg)]">
+          {error}
+        </div>
+      )}
 
       <div className="md:col-span-2">
         <button
           disabled={busy}
-          className="rounded-md bg-black px-5 py-2 text-sm text-white disabled:opacity-50"
+          className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-5 py-2 text-sm font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? "Saving…" : "Save item"}
         </button>
@@ -227,8 +234,10 @@ function Field({
   full?: boolean;
 }) {
   return (
-    <label className={`flex flex-col gap-1 text-sm ${full ? "md:col-span-2" : ""}`}>
-      <span className="text-xs uppercase text-gray-500">{label}</span>
+    <label className={`flex flex-col gap-1.5 text-sm ${full ? "md:col-span-2" : ""}`}>
+      <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        {label}
+      </span>
       {children}
     </label>
   );

--- a/src/app/(app)/inventory/new/form.tsx
+++ b/src/app/(app)/inventory/new/form.tsx
@@ -72,7 +72,7 @@ export function NewItemForm() {
   return (
     <form onSubmit={submit} className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="md:col-span-2">
-        <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Where did this come from?
         </span>
         <div
@@ -235,7 +235,7 @@ function Field({
 }) {
   return (
     <label className={`flex flex-col gap-1.5 text-sm ${full ? "md:col-span-2" : ""}`}>
-      <span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+      <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
         {label}
       </span>
       {children}

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { buildDailyPlan, type DailyTask, type TaskType } from "@/lib/analytics/daily-plan";
 import { userScope } from "@/lib/db/scoped";
 import { FirstRunNudge } from "@/components/FirstRunNudge";
+import { Card, PageHeader } from "@/components/ui";
 
 const TYPE_META: Record<
   TaskType,
@@ -11,22 +12,22 @@ const TYPE_META: Record<
 > = {
   ship: {
     label: "Ship",
-    tone: "bg-emerald-100 text-emerald-800",
+    tone: "bg-[var(--accent-emerald-soft)] text-[var(--accent-emerald-soft-fg)]",
     emptyLabel: "Nothing to ship",
   },
   update: {
     label: "Update",
-    tone: "bg-blue-100 text-blue-800",
+    tone: "bg-[var(--accent-blue-soft)] text-[var(--accent-blue-soft-fg)]",
     emptyLabel: "All details filled in",
   },
   reprice: {
     label: "Reprice",
-    tone: "bg-amber-100 text-amber-800",
+    tone: "bg-[var(--accent-amber-soft)] text-[var(--accent-amber-soft-fg)]",
     emptyLabel: "No stale listings",
   },
   photo: {
     label: "Photos",
-    tone: "bg-fuchsia-100 text-fuchsia-800",
+    tone: "bg-[var(--accent-violet-soft)] text-[var(--accent-violet-soft-fg)]",
     emptyLabel: "All listings have photos",
   },
 };
@@ -57,29 +58,21 @@ export default async function PlanPage() {
   });
 
   return (
-    <div className="space-y-8">
-      <header className="flex items-end justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Plan my day</h1>
-          <p className="mt-1 text-sm text-gray-600">{today}</p>
-        </div>
-        <div className="text-right">
-          <div className="text-xs uppercase text-gray-500">Total time</div>
-          <div className="text-xl font-semibold">
-            {plan.totalEstimatedMinutes ? `~${plan.totalEstimatedMinutes} min` : "—"}
+    <div className="space-y-6">
+      <PageHeader
+        title="Plan my day"
+        subtitle={today}
+        actions={
+          <div className="text-right">
+            <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+              Total time
+            </div>
+            <div className="font-display text-xl font-semibold text-[var(--text-primary)] tabular-nums">
+              {plan.totalEstimatedMinutes ? `~${plan.totalEstimatedMinutes} min` : "—"}
+            </div>
           </div>
-        </div>
-      </header>
-
-      {/* Counts */}
-      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        {ORDER.map((t) => (
-          <div key={t} className="rounded-md border p-4">
-            <div className="text-xs uppercase text-gray-500">{TYPE_META[t].label}</div>
-            <div className="mt-1 text-2xl font-semibold">{plan.countsByType[t]}</div>
-          </div>
-        ))}
-      </section>
+        }
+      />
 
       {isFirstRun ? (
         <FirstRunNudge
@@ -87,59 +80,85 @@ export default async function PlanPage() {
           heading="No tasks yet"
           body="Once you add items, the daily plan will surface what to ship, photo, reprice or update first."
         />
-      ) : plan.tasks.length === 0 ? (
-        <section className="rounded-md border border-dashed bg-gray-50 p-10 text-center">
-          <p className="text-base font-medium">Inbox zero</p>
-          <p className="mt-1 text-sm text-gray-600">
-            Nothing urgent — go source some stock or take the afternoon off.
-          </p>
-        </section>
       ) : (
-        ORDER.map((type) => (
-          <section key={type}>
-            <header className="mb-2 flex items-center gap-2">
-              <span
-                className={`rounded px-1.5 py-0.5 text-xs font-medium ${TYPE_META[type].tone}`}
-              >
-                {TYPE_META[type].label}
-              </span>
-              <h2 className="text-sm font-medium text-gray-700">
-                {grouped[type].length > 0
-                  ? `${grouped[type].length} ${grouped[type].length === 1 ? "task" : "tasks"}`
-                  : TYPE_META[type].emptyLabel}
-              </h2>
-            </header>
-            {grouped[type].length === 0 ? null : (
-              <ul className="divide-y rounded-md border">
-                {grouped[type].map((task) => (
-                  <li
-                    key={task.id}
-                    className="flex items-center justify-between gap-3 px-4 py-3"
-                  >
-                    <div className="min-w-0">
-                      <Link
-                        href={`/inventory/${task.itemId}`}
-                        className="block truncate text-sm font-medium underline"
-                      >
-                        {task.title}
-                      </Link>
-                      <p className="truncate text-xs text-gray-600">{task.subtitle}</p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-3 text-xs text-gray-500">
-                      <span>~{task.estimatedMinutes}m</span>
-                      <Link
-                        href={`/inventory/${task.itemId}`}
-                        className="rounded-md border px-2 py-1 text-gray-700 hover:bg-gray-50"
-                      >
-                        {task.action}
-                      </Link>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
+        <>
+          {/* Counts */}
+          <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            {ORDER.map((t) => (
+              <Card key={t} className="!p-4">
+                <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                  {TYPE_META[t].label}
+                </div>
+                <div className="mt-1 font-display text-2xl font-semibold text-[var(--text-primary)] tabular-nums">
+                  {plan.countsByType[t]}
+                </div>
+              </Card>
+            ))}
           </section>
-        ))
+
+          {plan.tasks.length === 0 ? (
+            <Card className="text-center !p-10">
+              <p className="font-display text-lg font-semibold text-[var(--text-primary)]">
+                Inbox zero
+              </p>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                Nothing urgent — go source some stock or take the afternoon off.
+              </p>
+            </Card>
+          ) : (
+            <div className="space-y-6">
+              {ORDER.map((type) => (
+                <section key={type}>
+                  <header className="mb-2 flex items-center gap-2">
+                    <span
+                      className={`rounded-[var(--radius-sm)] px-1.5 py-0.5 text-xs font-medium ${TYPE_META[type].tone}`}
+                    >
+                      {TYPE_META[type].label}
+                    </span>
+                    <h2 className="text-sm font-medium text-[var(--text-secondary)]">
+                      {grouped[type].length > 0
+                        ? `${grouped[type].length} ${grouped[type].length === 1 ? "task" : "tasks"}`
+                        : TYPE_META[type].emptyLabel}
+                    </h2>
+                  </header>
+                  {grouped[type].length === 0 ? null : (
+                    <Card padded={false}>
+                      <ul className="divide-y divide-[var(--border-subtle)]">
+                        {grouped[type].map((task) => (
+                          <li
+                            key={task.id}
+                            className="flex items-center justify-between gap-3 px-4 py-3"
+                          >
+                            <div className="min-w-0">
+                              <Link
+                                href={`/inventory/${task.itemId}`}
+                                className="block truncate text-sm font-medium text-[var(--text-primary)] hover:text-[var(--brand)]"
+                              >
+                                {task.title}
+                              </Link>
+                              <p className="truncate text-xs text-[var(--text-muted)]">
+                                {task.subtitle}
+                              </p>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-3 text-xs text-[var(--text-muted)]">
+                              <span className="tabular-nums">~{task.estimatedMinutes}m</span>
+                              <Link
+                                href={`/inventory/${task.itemId}`}
+                                className="inline-flex items-center rounded-[var(--radius-sm)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-2 py-1 text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                              >
+                                {task.action}
+                              </Link>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </Card>
+                  )}
+                </section>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -64,7 +64,7 @@ export default async function PlanPage() {
         subtitle={today}
         actions={
           <div className="text-right">
-            <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            <div className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
               Total time
             </div>
             <div className="font-display text-xl font-semibold text-[var(--text-primary)] tabular-nums">
@@ -86,7 +86,7 @@ export default async function PlanPage() {
           <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
             {ORDER.map((t) => (
               <Card key={t} className="!p-4">
-                <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+                <div className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
                   {TYPE_META[t].label}
                 </div>
                 <div className="mt-1 font-display text-2xl font-semibold text-[var(--text-primary)] tabular-nums">

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -215,13 +215,14 @@ export default async function ProfitPage({
         }
       />
 
-      {isFirstRun && (
+      {isFirstRun ? (
         <FirstRunNudge
+          variant="panel"
           heading="No profit data yet"
           body="Add items and mark them sold to see revenue, margin and net profit broken down."
         />
-      )}
-
+      ) : (
+        <>
       {/* Tile row — single grid, 7 metrics */}
       <section className="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-7">
         <Tile
@@ -337,6 +338,8 @@ export default async function ProfitPage({
           />
         )}
       </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -30,7 +30,7 @@ export default async function MarketingPage() {
             </>
           ) : (
             <div className="[&_button]:bg-brand-gradient [&_button]:text-[var(--text-inverse)] [&_button]:shadow-brand-glow [&_button]:inline-flex [&_button]:h-9 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-[var(--radius-md)] [&_button]:px-4 [&_button]:text-[13px] [&_button]:font-semibold [&_button]:cursor-pointer [&_button:hover]:brightness-110">
-              <SignInButton mode="modal">
+              <SignInButton mode="modal" fallbackRedirectUrl="/dashboard">
                 <button>Sign in</button>
               </SignInButton>
             </div>
@@ -82,7 +82,7 @@ export default async function MarketingPage() {
               </div>
             ) : (
               <div className="[&_button]:bg-brand-gradient [&_button]:text-[var(--text-inverse)] [&_button]:shadow-brand-glow [&_button]:inline-flex [&_button]:h-11 [&_button]:items-center [&_button]:justify-center [&_button]:rounded-[var(--radius-md)] [&_button]:px-6 [&_button]:text-sm [&_button]:font-semibold [&_button]:cursor-pointer [&_button:hover]:brightness-110">
-                <SignInButton mode="modal">
+                <SignInButton mode="modal" fallbackRedirectUrl="/dashboard">
                   <button>Sign in →</button>
                 </SignInButton>
               </div>

--- a/src/components/FirstRunNudge.tsx
+++ b/src/components/FirstRunNudge.tsx
@@ -16,27 +16,29 @@ export function FirstRunNudge({
 }) {
   const wrap =
     variant === "banner"
-      ? "rounded-md border border-blue-200 bg-blue-50 p-5"
-      : "rounded-md border border-dashed bg-gray-50 p-10 text-center";
+      ? "rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-1)] p-5"
+      : "rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-1)] p-10 text-center";
 
   return (
     <section className={wrap}>
-      <p className="text-base font-medium">{heading}</p>
-      <p className="mt-1 text-sm text-gray-700">{body}</p>
+      <p className="font-display text-lg font-semibold text-[var(--text-primary)]">
+        {heading}
+      </p>
+      <p className="mt-1 text-sm text-[var(--text-secondary)]">{body}</p>
       <div
-        className={`mt-3 flex flex-wrap gap-2 text-sm ${
+        className={`mt-4 flex flex-wrap gap-2 text-sm ${
           variant === "panel" ? "justify-center" : ""
         }`}
       >
         <Link
           href="/inventory/new"
-          className="rounded-md bg-black px-3 py-1.5 text-white"
+          className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-3.5 py-1.5 text-[13px] font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110"
         >
           Add your first item
         </Link>
         <Link
           href="/settings/api-keys"
-          className="rounded-md border px-3 py-1.5"
+          className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
         >
           Set up the extension
         </Link>
@@ -44,9 +46,9 @@ export function FirstRunNudge({
           <form action={loadSampleDataAction}>
             <button
               type="submit"
-              className="rounded-md border px-3 py-1.5"
+              className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
             >
-              Load sample data
+              Show me a tour with fake data
             </button>
           </form>
         )}

--- a/src/components/FirstRunNudge.tsx
+++ b/src/components/FirstRunNudge.tsx
@@ -14,44 +14,73 @@ export function FirstRunNudge({
   body?: string;
   showSampleData?: boolean;
 }) {
-  const wrap =
-    variant === "banner"
-      ? "rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-1)] p-5"
-      : "rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] shadow-[var(--elev-1)] p-10 text-center";
+  const isPanel = variant === "panel";
 
   return (
-    <section className={wrap}>
-      <p className="font-display text-lg font-semibold text-[var(--text-primary)]">
-        {heading}
-      </p>
-      <p className="mt-1 text-sm text-[var(--text-secondary)]">{body}</p>
-      <div
-        className={`mt-4 flex flex-wrap gap-2 text-sm ${
-          variant === "panel" ? "justify-center" : ""
-        }`}
-      >
-        <Link
-          href="/inventory/new"
-          className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-3.5 py-1.5 text-[13px] font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110"
+    <section
+      className={
+        isPanel
+          ? "relative overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-8 py-12 text-center shadow-[var(--elev-1)] md:px-12 md:py-16"
+          : "rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5 shadow-[var(--elev-1)]"
+      }
+    >
+      {isPanel && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 -z-0 opacity-60"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(94, 234, 212, 0.10), transparent 60%)",
+          }}
+        />
+      )}
+      <div className="relative">
+        <p
+          className={
+            isPanel
+              ? "font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl"
+              : "font-display text-lg font-semibold text-[var(--text-primary)]"
+          }
         >
-          Add your first item
-        </Link>
-        <Link
-          href="/settings/api-keys"
-          className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          {heading}
+        </p>
+        <p
+          className={
+            isPanel
+              ? "mx-auto mt-3 max-w-xl text-[15px] leading-relaxed text-[var(--text-secondary)]"
+              : "mt-1 text-[14px] text-[var(--text-secondary)]"
+          }
         >
-          Set up the extension
-        </Link>
-        {showSampleData && (
-          <form action={loadSampleDataAction}>
-            <button
-              type="submit"
-              className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-3.5 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            >
-              Show me a tour with fake data
-            </button>
-          </form>
-        )}
+          {body}
+        </p>
+        <div
+          className={`mt-5 flex flex-wrap gap-2 text-sm ${
+            isPanel ? "justify-center" : ""
+          }`}
+        >
+          <Link
+            href="/inventory/new"
+            className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-4 py-2 text-[13px] font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110"
+          >
+            Add your first item
+          </Link>
+          <Link
+            href="/settings/api-keys"
+            className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-4 py-2 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+          >
+            Set up the extension
+          </Link>
+          {showSampleData && (
+            <form action={loadSampleDataAction}>
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-glass)] px-4 py-2 text-[13px] font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              >
+                Show me a tour with fake data
+              </button>
+            </form>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -30,9 +30,9 @@ export function CardHeader({
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <h3 className="text-base font-semibold text-[var(--text-primary)]">{title}</h3>
+        <h3 className="text-[17px] font-semibold tracking-tight text-[var(--text-primary)]">{title}</h3>
         {description && (
-          <p className="mt-1 text-sm text-[var(--text-secondary)]">{description}</p>
+          <p className="mt-1 text-[13px] text-[var(--text-secondary)]">{description}</p>
         )}
       </div>
       {action && <div className="shrink-0">{action}</div>}

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -10,7 +10,7 @@ export function PageHeader({ title, subtitle, actions }: Props) {
   return (
     <header className="flex flex-wrap items-end justify-between gap-4">
       <div>
-        <h1 className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+        <h1 className="font-display text-[26px] font-semibold tracking-tight text-[var(--text-primary)] md:text-[30px]">
           {title}
         </h1>
         {subtitle && (

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -14,7 +14,7 @@ export function PageHeader({ title, subtitle, actions }: Props) {
           {title}
         </h1>
         {subtitle && (
-          <p className="mt-1 text-sm text-[var(--text-secondary)]">{subtitle}</p>
+          <p className="mt-1.5 text-[15px] text-[var(--text-secondary)]">{subtitle}</p>
         )}
       </div>
       {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}

--- a/src/components/ui/Tile.tsx
+++ b/src/components/ui/Tile.tsx
@@ -44,10 +44,10 @@ export function Tile({
   spark,
 }: Props) {
   return (
-    <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-4 shadow-[var(--elev-1)]">
+    <div className="rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] p-3.5 shadow-[var(--elev-1)]">
       <div className="flex items-start justify-between gap-3">
         {icon && (
-          <span className={`inline-flex h-9 w-9 items-center justify-center rounded-[var(--radius-md)] ${ICON_BG[tone]}`}>
+          <span className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-md)] ${ICON_BG[tone]}`}>
             {icon}
           </span>
         )}
@@ -58,21 +58,21 @@ export function Tile({
         )}
       </div>
 
-      <div className="mt-3">
+      <div className="mt-2.5">
         <div className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
           {label}
         </div>
-        <div className="mt-1.5 text-[26px] font-semibold tracking-tight tabular-nums text-[var(--text-primary)] md:text-[30px]">
+        <div className="mt-1 text-[24px] font-semibold tracking-tight tabular-nums text-[var(--text-primary)] md:text-[28px]">
           {value}
         </div>
         {sub && (
-          <div className="mt-1 text-[13px] text-[var(--text-secondary)]">{sub}</div>
+          <div className="mt-0.5 text-[13px] text-[var(--text-secondary)]">{sub}</div>
         )}
       </div>
 
       {spark && spark.length > 1 && (
-        <div className="mt-3">
-          <Sparkline data={spark} tone={tone} height={36} />
+        <div className="mt-2">
+          <Sparkline data={spark} tone={tone} height={28} />
         </div>
       )}
     </div>

--- a/src/components/ui/Tile.tsx
+++ b/src/components/ui/Tile.tsx
@@ -59,14 +59,14 @@ export function Tile({
       </div>
 
       <div className="mt-3">
-        <div className="text-xs uppercase tracking-wide text-[var(--text-muted)]">
+        <div className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
           {label}
         </div>
-        <div className="mt-1 text-2xl font-semibold tracking-tight tabular-nums text-[var(--text-primary)] md:text-3xl">
+        <div className="mt-1.5 text-[26px] font-semibold tracking-tight tabular-nums text-[var(--text-primary)] md:text-[30px]">
           {value}
         </div>
         {sub && (
-          <div className="mt-1 text-xs text-[var(--text-muted)]">{sub}</div>
+          <div className="mt-1 text-[13px] text-[var(--text-secondary)]">{sub}</div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

Pre-invite UX pass from the onboarding audit (#64). Bar: a fresh family-member invite lands somewhere that looks intentional, not "data fetch broken".

- **Clerk redirect** — \`SignInButton fallbackRedirectUrl="/dashboard"\` so invited users land on the app, not back on the marketing page (\`src/app/(marketing)/page.tsx\`).
- **FirstRunNudge rewritten in Aurora** — was \`bg-blue-50\` / \`bg-black\` against the dark theme; now uses Card surface tokens + brand-gradient primary CTA. Sample-data button copy is now "Show me a tour with fake data".
- **\`/plan\` page restyled to Aurora** — \`Card\` + \`PageHeader\` + accent-soft chips replace pre-Aurora \`bg-gray\` / \`text-gray\` / \`emerald-100\` colours.
- **\`/inventory/new\` form restyled to Aurora** — every input + select + textarea uses the dark glass surface; brand-gradient submit button.
- **First-run zero-noise suppression**:
  - Dashboard hides the 4-tile row + Top-Profit table when \`itemCount===0\`.
  - Profit hides the 7-tile row, chart, and tabbed section.
  - Health hides everything below the nudge (kills the "Behind / 0% of pace" scolding on a brand-new account).

## Out of scope — filed as follow-up issues

- #71 Aurora-native OnboardingPanel (full rebuild of the nudge into a 3-path welcome surface)
- #72 Post-sign-in welcome toast with the user's first name
- #73 Photo upload on item creation — **this is the actual bar for "ready to invite"**
- #74 Zero-aware copy when listings > 0 but sales == 0
- #75 Settings → Profile tab
- #76 HelpDot glossary tooltips for Vinted jargon
- #77 Optional 3-step coach mark sequence

## Test plan

- [ ] 1280×800 desktop no-scroll on Dashboard / Inventory / Profit / Health / Plan with **zero** items
- [ ] 1280×800 desktop no-scroll on the same pages with one item added
- [ ] Sign in with a fresh personal email via Clerk Invitation → lands on \`/dashboard\` (not marketing)
- [ ] FirstRunNudge "Add your first item" → \`/inventory/new\` works
- [ ] New-item form submit creates an item and redirects to detail
- [ ] Plan page renders correctly with at least one item

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)