### PR TITLE
Allow .env.example to be committed and refresh template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Neon Postgres — pooled connection string
+DATABASE_URL=postgres://user:pass@host/dbname?sslmode=require
+
+# Clerk (https://dashboard.clerk.com → API keys)
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+# Force where Clerk lands users post-auth. Without these, Clerk falls back to
+# /default-redirect on its own domain when extensions / quirky browsers strip
+# the redirect_url param — produces a confusing dead-end.
+NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL=/dashboard
+NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL=/dashboard
+
+# Vercel Blob — used for item photo uploads
+BLOB_READ_WRITE_TOKEN=
+
+# Optional — OpenRouter API key. Falls back to free models when unset.
+OPENROUTER_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
Closes #79

- `.gitignore`: add `!.env.example` exception so the template can live in version control again (previously caught by `.env*`)
- Refresh `.env.example` with currently-required vars including the two Clerk force-redirect URLs from #78 and `BLOB_READ_WRITE_TOKEN`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>