### PR TITLE
Inventory: photo upload on item creation (closes #73)

### DIFF
--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -91,12 +91,16 @@ export default async function HealthPage() {
   if (!userId) redirect("/");
 
   const scope = userScope(userId);
-  const [h, itemCount] = await Promise.all([
+  const [h, itemCount, soldCount] = await Promise.all([
     computeHealth(userId),
     scope.countItems(),
+    scope.countSoldItems(),
   ]);
 
   const isFirstRun = itemCount === 0;
+  // Phase 2: user has listings but zero sales — soften the "Behind / X% of pace"
+  // pill so it doesn't scold someone who's just started. (issue #74)
+  const isPreFirstSale = !isFirstRun && soldCount === 0;
   const totalAging = Object.values(h.aging.buckets).reduce((a, b) => a + b, 0);
 
   // Enrich topGaps rows with item names (one round-trip).
@@ -157,8 +161,12 @@ export default async function HealthPage() {
         <Tile
           label="This week's listings"
           value={`${h.cadence.currentCount} / ${h.cadence.target}`}
-          sub={`${PACE_LABEL[h.cadence.paceBand]} · ${Math.round(h.cadence.pace * 100)}% of pace`}
-          tone={paceTone}
+          sub={
+            isPreFirstSale
+              ? "Your listings look healthy — sales will appear once you mark one sold."
+              : `${PACE_LABEL[h.cadence.paceBand]} · ${Math.round(h.cadence.pace * 100)}% of pace`
+          }
+          tone={isPreFirstSale ? "emerald" : paceTone}
           icon={<BoltIcon />}
         />
       </section>

--- a/src/app/(app)/inventory/new/form.tsx
+++ b/src/app/(app)/inventory/new/form.tsx
@@ -2,6 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import {
+  MAX_BATCH,
+  PhotoDropzone,
+  type StagedPhoto,
+} from "@/components/PhotoDropzone";
 
 type AcquisitionType = "bought" | "own";
 
@@ -14,6 +19,8 @@ export function NewItemForm() {
   const [error, setError] = useState<string | null>(null);
   const [acquisitionType, setAcquisitionType] =
     useState<AcquisitionType>("bought");
+  const [photos, setPhotos] = useState<StagedPhoto[]>([]);
+  const [photoNote, setPhotoNote] = useState<string | null>(null);
   const [form, setForm] = useState({
     name: "",
     brand: "",
@@ -35,6 +42,7 @@ export function NewItemForm() {
     e.preventDefault();
     setBusy(true);
     setError(null);
+    setPhotoNote(null);
     try {
       // 'own' items always have cost = 0 (cleaner than null going forward).
       const costPrice =
@@ -60,6 +68,32 @@ export function NewItemForm() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Failed");
+
+      // Upload any staged photos to the freshly-created item.  The photos API
+      // caps each request at MAX_BATCH (5), so we chunk if needed.  If a chunk
+      // fails we still navigate to the item — the user can finish from the
+      // detail page rather than losing the item they just created.
+      if (photos.length > 0) {
+        const itemId: string = data.item.id;
+        for (let i = 0; i < photos.length; i += MAX_BATCH) {
+          const chunk = photos.slice(i, i + MAX_BATCH);
+          const upload = await fetch(`/api/inventory/${itemId}/photos`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ photos: chunk.map((p) => p.dataUri) }),
+          });
+          if (!upload.ok) {
+            const body = await upload.json().catch(() => ({}));
+            setPhotoNote(
+              `Item saved, but photo upload failed: ${
+                body.error ?? upload.statusText
+              }. You can add them on the item page.`,
+            );
+            break;
+          }
+        }
+      }
+
       router.push(`/inventory/${data.item.id}`);
       router.refresh();
     } catch (err) {
@@ -70,7 +104,7 @@ export function NewItemForm() {
   }
 
   return (
-    <form onSubmit={submit} className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+    <form onSubmit={submit} className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
       <div className="md:col-span-2">
         <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Where did this come from?
@@ -201,10 +235,24 @@ export function NewItemForm() {
         <textarea
           value={form.description}
           onChange={(e) => set("description", e.target.value)}
-          rows={3}
+          rows={2}
           className={INPUT_CLASS}
         />
       </Field>
+
+      <div className="md:col-span-2">
+        <PhotoDropzone
+          photos={photos}
+          onChange={setPhotos}
+          disabled={busy}
+        />
+      </div>
+
+      {photoNote && (
+        <div className="md:col-span-2 rounded-[var(--radius-md)] border border-[var(--accent-rose-soft)] bg-[var(--accent-rose-soft)] px-3 py-2 text-sm text-[var(--accent-rose-soft-fg)]">
+          {photoNote}
+        </div>
+      )}
 
       {error && (
         <div className="md:col-span-2 rounded-[var(--radius-md)] border border-[var(--accent-rose-soft)] bg-[var(--accent-rose-soft)] px-3 py-2 text-sm text-[var(--accent-rose-soft-fg)]">

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -149,6 +149,10 @@ export default async function ProfitPage({
 
   const isFirstRun = itemCount === 0;
   const s = r.summary;
+  // Phase 2 of onboarding: user has listed items but hasn't logged any sale yet.
+  // Showing £0.00 tiles + 0% margin reads as punitive — swap for an encouraging
+  // panel until the first sale lands. (issue #74)
+  const isPreFirstSale = !isFirstRun && s.itemsSold === 0;
 
   // ----- Items tab: filter, sort, paginate in-memory -----
   const qLower = p.q.toLowerCase();
@@ -221,6 +225,35 @@ export default async function ProfitPage({
           heading="No profit data yet"
           body="Add items and mark them sold to see revenue, margin and net profit broken down."
         />
+      ) : isPreFirstSale ? (
+        <section className="relative overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-8 py-12 text-center shadow-[var(--elev-1)] md:px-12 md:py-16">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -z-0 opacity-60"
+            style={{
+              background:
+                "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(94, 234, 212, 0.10), transparent 60%)",
+            }}
+          />
+          <div className="relative">
+            <p className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+              No sales yet — but {itemCount}{" "}
+              {itemCount === 1 ? "item is" : "items are"} listed
+            </p>
+            <p className="mx-auto mt-3 max-w-xl text-[15px] leading-relaxed text-[var(--text-secondary)]">
+              Mark one sold to see revenue, margins and your best performers
+              broken down here.
+            </p>
+            <div className="mt-5 flex flex-wrap justify-center gap-2 text-sm">
+              <Link
+                href="/inventory"
+                className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-4 py-2 text-[13px] font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110"
+              >
+                Go to inventory
+              </Link>
+            </div>
+          </div>
+        </section>
       ) : (
         <>
       {/* Tile row — single grid, 7 metrics */}

--- a/src/components/PhotoDropzone.tsx
+++ b/src/components/PhotoDropzone.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui";
+
+export const MAX_PHOTOS_PER_ITEM = 10;
+export const MAX_BATCH = 5;
+
+export type StagedPhoto = {
+  dataUri: string;
+  name: string;
+};
+
+async function fileToDataUri(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export function PhotoDropzone({
+  photos,
+  onChange,
+  disabled,
+  max = MAX_PHOTOS_PER_ITEM,
+}: {
+  photos: StagedPhoto[];
+  onChange: (next: StagedPhoto[]) => void;
+  disabled?: boolean;
+  max?: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canAdd = photos.length < max && !disabled;
+
+  async function ingest(list: FileList | File[]) {
+    setError(null);
+    const slots = max - photos.length;
+    if (slots <= 0) {
+      setError(`Max ${max} photos.`);
+      return;
+    }
+    const files = Array.from(list).filter((f) => f.type.startsWith("image/"));
+    if (files.length === 0) return;
+    const accepted = files.slice(0, slots);
+    try {
+      const added: StagedPhoto[] = [];
+      for (const file of accepted) {
+        const dataUri = await fileToDataUri(file);
+        added.push({ dataUri, name: file.name });
+      }
+      onChange([...photos, ...added]);
+      if (files.length > accepted.length) {
+        setError(`Only added ${accepted.length} — ${max}-photo cap.`);
+      }
+    } catch {
+      setError("Could not read one or more files.");
+    }
+  }
+
+  function removeAt(index: number) {
+    onChange(photos.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Photos
+          {photos.length > 0 && (
+            <span className="ml-1 normal-case tracking-normal text-[var(--text-muted)]">
+              · {photos.length}/{max}
+            </span>
+          )}
+        </span>
+        {canAdd && (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={() => inputRef.current?.click()}
+            disabled={!canAdd}
+          >
+            Add photos
+          </Button>
+        )}
+      </div>
+
+      <div
+        onDragOver={(e) => {
+          if (!canAdd) return;
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          if (!canAdd) return;
+          e.preventDefault();
+          setDragging(false);
+          if (e.dataTransfer.files?.length) ingest(e.dataTransfer.files);
+        }}
+        onClick={() => canAdd && inputRef.current?.click()}
+        role="button"
+        tabIndex={canAdd ? 0 : -1}
+        aria-label="Add photos"
+        onKeyDown={(e) => {
+          if (!canAdd) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        className={`flex min-h-[88px] w-full cursor-pointer items-center justify-center rounded-[var(--radius-lg)] border border-dashed px-3 py-3 text-center text-xs transition-colors ${
+          dragging
+            ? "border-[var(--brand)] bg-[var(--brand-soft)]/30"
+            : "border-[var(--border-subtle)] bg-[var(--surface-inset)] hover:border-[var(--border-default)]"
+        } ${!canAdd ? "cursor-not-allowed opacity-60" : ""}`}
+      >
+        {photos.length === 0 ? (
+          <span className="text-[var(--text-muted)]">
+            Drop photos here or click to choose — up to {max}. First one becomes the thumbnail.
+          </span>
+        ) : (
+          <div className="flex w-full flex-wrap gap-2">
+            {photos.map((p, i) => (
+              <div
+                key={i}
+                className="relative h-16 w-16 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-card)]"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={p.dataUri}
+                  alt={p.name}
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  aria-label={`Remove ${p.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeAt(i);
+                  }}
+                  disabled={disabled}
+                  className="absolute right-0 top-0 rounded-bl-[var(--radius-sm)] bg-black/65 px-1.5 py-0.5 text-[10px] font-medium text-white hover:bg-black/80 disabled:opacity-50"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {canAdd && (
+              <div className="flex h-16 w-16 items-center justify-center rounded-[var(--radius-md)] border border-dashed border-[var(--border-subtle)] text-[var(--text-muted)]">
+                +
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-[11px] text-[var(--accent-rose-soft-fg)]">{error}</p>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files) ingest(e.target.files);
+          e.target.value = "";
+        }}
+      />
+    </div>
+  );
+}

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -249,6 +249,19 @@ export function userScope(userId: string) {
       return Number(row?.n ?? 0);
     },
 
+    countSoldItems: async () => {
+      const [row] = await db
+        .select({ n: count() })
+        .from(items)
+        .where(
+          and(
+            eq(items.userId, userId),
+            or(eq(items.status, "sold"), eq(items.status, "shipped")),
+          ),
+        );
+      return Number(row?.n ?? 0);
+    },
+
     getItem: async (id: string) => {
       const [row] = await db
         .select()


### PR DESCRIPTION
Closes #73.

## Summary
- New reusable `<PhotoDropzone />` component (`src/components/PhotoDropzone.tsx`) with drag-and-drop + click-to-choose, thumbnail strip, per-photo remove, and the same 10-photo cap as the item detail page.
- Wired into the new-item form (`src/app/(app)/inventory/new/form.tsx`): on submit we create the item, then POST staged photos as base64 data URIs to the existing `/api/inventory/[id]/photos` endpoint in chunks of `MAX_BATCH` (5).
- No new infrastructure — reuses the existing Vercel Blob resize pipeline (`resizeAndUploadFromDataUri`). Hosting cap respected.
- If photo upload fails after item creation, the user gets a soft notice and still lands on the item detail page so they can retry there — they never lose the item they just typed in.
- Minor form tightening (gap 4→3, mt-6→4, description rows 3→2) to keep 1280x800 no-scroll comfortable now that the dropzone takes a row.

Kills the day-one "no img" placeholder for invited users — onboarding audit #64 bigger play 3.

## Test plan
- [ ] Create item with 0 photos — works as before.
- [ ] Create item with 1-5 photos via click — item lands on detail page with photos already attached, no "no img".
- [ ] Create item with 6-10 photos — chunked into two POSTs, all land.
- [ ] Drag-and-drop a folder of images — only images accepted, capped at 10.
- [ ] Remove a staged photo before submit — it disappears from the dropzone.
- [ ] Verify 1280x800 viewport — form fits without page scroll on first reveal.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>