### PR TITLE
Health & Profit: zero-aware copy when listings > 0 but sales == 0 (closes #74)

### DIFF
--- a/src/app/(app)/health/page.tsx
+++ b/src/app/(app)/health/page.tsx
@@ -91,12 +91,16 @@ export default async function HealthPage() {
   if (!userId) redirect("/");
 
   const scope = userScope(userId);
-  const [h, itemCount] = await Promise.all([
+  const [h, itemCount, soldCount] = await Promise.all([
     computeHealth(userId),
     scope.countItems(),
+    scope.countSoldItems(),
   ]);
 
   const isFirstRun = itemCount === 0;
+  // Phase 2: user has listings but zero sales — soften the "Behind / X% of pace"
+  // pill so it doesn't scold someone who's just started. (issue #74)
+  const isPreFirstSale = !isFirstRun && soldCount === 0;
   const totalAging = Object.values(h.aging.buckets).reduce((a, b) => a + b, 0);
 
   // Enrich topGaps rows with item names (one round-trip).
@@ -157,8 +161,12 @@ export default async function HealthPage() {
         <Tile
           label="This week's listings"
           value={`${h.cadence.currentCount} / ${h.cadence.target}`}
-          sub={`${PACE_LABEL[h.cadence.paceBand]} · ${Math.round(h.cadence.pace * 100)}% of pace`}
-          tone={paceTone}
+          sub={
+            isPreFirstSale
+              ? "Your listings look healthy — sales will appear once you mark one sold."
+              : `${PACE_LABEL[h.cadence.paceBand]} · ${Math.round(h.cadence.pace * 100)}% of pace`
+          }
+          tone={isPreFirstSale ? "emerald" : paceTone}
           icon={<BoltIcon />}
         />
       </section>

--- a/src/app/(app)/profit/page.tsx
+++ b/src/app/(app)/profit/page.tsx
@@ -149,6 +149,10 @@ export default async function ProfitPage({
 
   const isFirstRun = itemCount === 0;
   const s = r.summary;
+  // Phase 2 of onboarding: user has listed items but hasn't logged any sale yet.
+  // Showing £0.00 tiles + 0% margin reads as punitive — swap for an encouraging
+  // panel until the first sale lands. (issue #74)
+  const isPreFirstSale = !isFirstRun && s.itemsSold === 0;
 
   // ----- Items tab: filter, sort, paginate in-memory -----
   const qLower = p.q.toLowerCase();
@@ -221,6 +225,35 @@ export default async function ProfitPage({
           heading="No profit data yet"
           body="Add items and mark them sold to see revenue, margin and net profit broken down."
         />
+      ) : isPreFirstSale ? (
+        <section className="relative overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border-subtle)] bg-[var(--surface-card)] px-8 py-12 text-center shadow-[var(--elev-1)] md:px-12 md:py-16">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 -z-0 opacity-60"
+            style={{
+              background:
+                "radial-gradient(ellipse 80% 60% at 50% 0%, rgba(94, 234, 212, 0.10), transparent 60%)",
+            }}
+          />
+          <div className="relative">
+            <p className="font-display text-3xl font-semibold tracking-tight text-[var(--text-primary)] md:text-4xl">
+              No sales yet — but {itemCount}{" "}
+              {itemCount === 1 ? "item is" : "items are"} listed
+            </p>
+            <p className="mx-auto mt-3 max-w-xl text-[15px] leading-relaxed text-[var(--text-secondary)]">
+              Mark one sold to see revenue, margins and your best performers
+              broken down here.
+            </p>
+            <div className="mt-5 flex flex-wrap justify-center gap-2 text-sm">
+              <Link
+                href="/inventory"
+                className="bg-brand-gradient inline-flex items-center rounded-[var(--radius-md)] px-4 py-2 text-[13px] font-semibold text-[var(--text-inverse)] shadow-brand-glow hover:brightness-110"
+              >
+                Go to inventory
+              </Link>
+            </div>
+          </div>
+        </section>
       ) : (
         <>
       {/* Tile row — single grid, 7 metrics */}

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -249,6 +249,19 @@ export function userScope(userId: string) {
       return Number(row?.n ?? 0);
     },
 
+    countSoldItems: async () => {
+      const [row] = await db
+        .select({ n: count() })
+        .from(items)
+        .where(
+          and(
+            eq(items.userId, userId),
+            or(eq(items.status, "sold"), eq(items.status, "shipped")),
+          ),
+        );
+      return Number(row?.n ?? 0);
+    },
+
     getItem: async (id: string) => {
       const [row] = await db
         .select()


### PR DESCRIPTION
## Summary

Closes #74 — phase 2 of the onboarding empty-state work (#64). When a user has added listings but hasn't logged a sale yet, the £0.00 tiles and "Behind / 0% of pace" pill read as punitive. Add a dedicated branch so those surfaces encourage instead of scold until the first sale lands.

- **Profit:** when `itemCount > 0 && itemsSold === 0`, replace the tile grid + chart + tabbed section with a centred panel styled to match `FirstRunNudge` — "No sales yet — but N items are listed" with a sub-line and a "Go to inventory" CTA. No fee copy anywhere (Vinted has no seller fees, per AGENTS.md).
- **Health:** keep the dashboard intact (the listing-quality data is genuinely useful pre-sale) but soften the "This week's listings" tile: replace the pace pill sub-text with "Your listings look healthy — sales will appear once you mark one sold." and force the emerald tone.
- **Data:** add `userScope().countSoldItems()` (counts items with `status in (sold, shipped)`) so Health can detect the pre-first-sale phase cheaply — one extra indexed count.

Bought-vs-own and the no-fees rules are untouched; the panel doesn't show any monetary tiles, so the `coerceMoney` / `own = 0 cost` paths aren't on the new code path. Fits 1280×800 (the panel is shorter than the original 4-tile + chart layout).

## Test plan

- [ ] Sign in as a fresh invited user with 0 items — Profit and Health still render the existing `FirstRunNudge` (unchanged).
- [ ] Add 1–3 items via /inventory/new, don't mark any sold — visit /profit: see the "No sales yet — but N items are listed" panel; visit /health: tile reads "Your listings look healthy — sales will appear once you mark one sold." with emerald tone.
- [ ] Mark one sold — both pages return to their full data layouts.
- [ ] Confirm 1280×800 fits without page scroll on both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)