### PR TITLE
HelpDot glossary tooltips for jargon terms

### DIFF
--- a/src/app/(app)/inventory/FiltersBar.tsx
+++ b/src/app/(app)/inventory/FiltersBar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { HelpDot } from "@/components/help/HelpDot";
 
 type StatusOption = { value: string; label: string };
 
@@ -75,7 +76,10 @@ export function FiltersBar({
         className="min-w-[220px] flex-1 rounded-[var(--radius-md)] border border-[var(--border-subtle)] bg-[var(--surface-inset)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--brand)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)]"
       />
       <label className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
-        <span className="hidden sm:inline">Status</span>
+        <span className="hidden items-center gap-1 sm:inline-flex">
+          Status
+          <HelpDot term="status" />
+        </span>
         <select
           value={status}
           onChange={(e) => {

--- a/src/app/(app)/inventory/[id]/page.tsx
+++ b/src/app/(app)/inventory/[id]/page.tsx
@@ -8,6 +8,7 @@ import { ItemActions } from "./actions";
 import { ItemPhotos } from "./photos";
 import { AcquisitionChip } from "./AcquisitionChip";
 import { EditDetails } from "./edit-details";
+import { HelpDot } from "@/components/help/HelpDot";
 
 function gbp(n: string | null) {
   return n == null ? "—" : `£${parseFloat(n).toFixed(2)}`;
@@ -70,8 +71,9 @@ export default async function ItemDetail({
             )}
           </div>
           <div className="flex items-center gap-2">
-            <StatusPill status={item.status} size="md" />
+            <StatusPill status={item.status} size="md" showHelp />
             <AcquisitionChip id={item.id} initial={item.acquisitionType} />
+            <HelpDot term="bought-vs-own" />
           </div>
         </div>
       </header>

--- a/src/app/(app)/inventory/new/form.tsx
+++ b/src/app/(app)/inventory/new/form.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { HelpDot } from "@/components/help/HelpDot";
+import type { GlossaryTerm } from "@/components/help/glossary";
 
 type AcquisitionType = "bought" | "own";
 
@@ -72,8 +74,9 @@ export function NewItemForm() {
   return (
     <form onSubmit={submit} className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="md:col-span-2">
-        <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        <span className="flex items-center gap-1.5 text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Where did this come from?
+          <HelpDot term="bought-vs-own" placement="bottom" />
         </span>
         <div
           role="radiogroup"
@@ -155,7 +158,7 @@ export function NewItemForm() {
         </select>
       </Field>
       {acquisitionType === "bought" && (
-        <Field label="Cost price (£)">
+        <Field label="Cost price (£)" help="cost-price">
           <input
             type="number"
             step="0.01"
@@ -174,7 +177,7 @@ export function NewItemForm() {
           className={INPUT_CLASS}
         />
       </Field>
-      <Field label="Status">
+      <Field label="Status" help="status">
         <select
           value={form.status}
           onChange={(e) =>
@@ -189,7 +192,7 @@ export function NewItemForm() {
           ))}
         </select>
       </Field>
-      <Field label="Vinted URL" full>
+      <Field label="Vinted URL" full help="vinted-url">
         <input
           type="url"
           value={form.vintedUrl}
@@ -228,15 +231,18 @@ function Field({
   label,
   children,
   full,
+  help,
 }: {
   label: string;
   children: React.ReactNode;
   full?: boolean;
+  help?: GlossaryTerm;
 }) {
   return (
     <label className={`flex flex-col gap-1.5 text-sm ${full ? "md:col-span-2" : ""}`}>
-      <span className="text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+      <span className="flex items-center gap-1.5 text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
         {label}
+        {help && <HelpDot term={help} />}
       </span>
       {children}
     </label>

--- a/src/components/help/HelpDot.tsx
+++ b/src/components/help/HelpDot.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { GLOSSARY, type GlossaryTerm } from "./glossary";
+
+type Props = {
+  term: GlossaryTerm;
+  /** Override the label read aloud by screen readers. Defaults to "More about {label}". */
+  ariaLabel?: string;
+  /** Where the tooltip floats relative to the dot. */
+  placement?: "top" | "bottom";
+  className?: string;
+};
+
+/**
+ * Tiny info-dot that reveals a one-sentence glossary entry on hover or
+ * focus. Keyboard-accessible: Tab to focus, Esc to dismiss. The tooltip
+ * is absolutely positioned so it doesn't push surrounding layout — safe
+ * inside tight Aurora cards and the 1280x800 no-scroll rule.
+ *
+ * Copy comes from `glossary.ts` keyed by `term`, so adding a new dot is
+ * a one-line change there.
+ */
+export function HelpDot({
+  term,
+  ariaLabel,
+  placement = "top",
+  className,
+}: Props) {
+  const entry = GLOSSARY[term];
+  const tipId = useId();
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+        btnRef.current?.blur();
+      }
+    }
+    function onDocClick(e: MouseEvent) {
+      if (!btnRef.current) return;
+      if (!btnRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onDocClick);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onDocClick);
+    };
+  }, [open]);
+
+  const positionClass =
+    placement === "bottom"
+      ? "top-full mt-2 left-1/2 -translate-x-1/2"
+      : "bottom-full mb-2 left-1/2 -translate-x-1/2";
+
+  return (
+    <span
+      className={`relative inline-flex align-middle ${className ?? ""}`}
+    >
+      <button
+        ref={btnRef}
+        type="button"
+        aria-label={ariaLabel ?? `More about ${entry.label}`}
+        aria-describedby={open ? tipId : undefined}
+        aria-expanded={open}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onClick={(e) => {
+          // Stop parent labels/links from swallowing the click.
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[var(--border-default)] bg-[var(--surface-inset)] text-[9px] font-semibold leading-none text-[var(--text-muted)] transition-colors hover:border-[var(--brand)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-soft)]"
+      >
+        <span aria-hidden>?</span>
+      </button>
+      {open && (
+        <span
+          id={tipId}
+          role="tooltip"
+          className={`pointer-events-none absolute z-50 w-56 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--surface-card)] px-3 py-2 text-[11px] leading-snug text-[var(--text-secondary)] shadow-[var(--elev-2)] ${positionClass}`}
+        >
+          <span className="block text-[11px] font-semibold text-[var(--text-primary)]">
+            {entry.label}
+          </span>
+          <span className="mt-0.5 block">{entry.description}</span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/help/glossary.ts
+++ b/src/components/help/glossary.ts
@@ -1,0 +1,55 @@
+/**
+ * Short, plain-English explainers for jargon that shows up across the app.
+ *
+ * Keyed by a stable slug so callers (`<HelpDot term="sourced" />`) stay
+ * one-liners. Add a new term here, then drop a HelpDot wherever the
+ * label appears. Keep copy to a single sentence — these render in a
+ * small floating tooltip and need to read at a glance.
+ *
+ * Vinted has no seller fees (see AGENTS.md), so there is intentionally
+ * no `fees` entry.
+ */
+export const GLOSSARY = {
+  sourced: {
+    label: "Sourced",
+    description:
+      "You've got it in hand but haven't listed it on Vinted yet — it's waiting to go up.",
+  },
+  listed: {
+    label: "Listed",
+    description:
+      "Live on Vinted right now and visible to buyers — no offer accepted yet.",
+  },
+  sold: {
+    label: "Sold",
+    description:
+      "A buyer has paid — you still need to pack and ship it for the sale to complete.",
+  },
+  shipped: {
+    label: "Shipped",
+    description:
+      "Handed off to the courier — the sale is on its way to the buyer.",
+  },
+  "bought-vs-own": {
+    label: "Bought vs Own",
+    description:
+      "Bought = you paid to source it for resale. Own = something already in your wardrobe; cost is treated as £0.",
+  },
+  "vinted-url": {
+    label: "Vinted URL",
+    description:
+      "Paste the link to your item's public Vinted listing so you can jump straight to it from here.",
+  },
+  "cost-price": {
+    label: "Cost price",
+    description:
+      "What you paid to source the item, before shipping or any prep costs.",
+  },
+  status: {
+    label: "Status",
+    description:
+      "Where this item is in its journey: Sourced → Listed → Sold → Shipped.",
+  },
+} as const;
+
+export type GlossaryTerm = keyof typeof GLOSSARY;

--- a/src/components/ui/StatusPill.tsx
+++ b/src/components/ui/StatusPill.tsx
@@ -1,21 +1,37 @@
+import { HelpDot } from "../help/HelpDot";
+import type { GlossaryTerm } from "../help/glossary";
 import { STATUS_LABEL, STATUS_PILL, type ItemStatus } from "./tokens";
 
 type Props = {
   status: ItemStatus | string;
   size?: "sm" | "md";
+  /** Opt-in glossary dot for first-time-user surfaces (detail header,
+   *  legends). Off by default so repeating list rows stay clean. */
+  showHelp?: boolean;
 };
 
-export function StatusPill({ status, size = "sm" }: Props) {
+// Status keys map 1:1 to glossary terms.
+const HELP_TERMS: Record<ItemStatus, GlossaryTerm> = {
+  sourced: "sourced",
+  listed: "listed",
+  sold: "sold",
+  shipped: "shipped",
+};
+
+export function StatusPill({ status, size = "sm", showHelp = false }: Props) {
   const key = (status in STATUS_LABEL ? status : "sourced") as ItemStatus;
   const tone = STATUS_PILL[key];
   const padding = size === "md" ? "px-2.5 py-1 text-xs" : "px-2 py-0.5 text-[11px]";
 
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full font-medium ${tone.bg} ${tone.fg} ${padding}`}
-    >
-      <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} aria-hidden />
-      {STATUS_LABEL[key]}
+    <span className="inline-flex items-center gap-1.5">
+      <span
+        className={`inline-flex items-center gap-1.5 rounded-full font-medium ${tone.bg} ${tone.fg} ${padding}`}
+      >
+        <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} aria-hidden />
+        {STATUS_LABEL[key]}
+      </span>
+      {showHelp && <HelpDot term={HELP_TERMS[key]} />}
     </span>
   );
 }


### PR DESCRIPTION
Closes #76.

## Summary
- New `<HelpDot term="..." />` component: small `?` info-dot with an Aurora-themed tooltip on hover/focus, keyboard accessible (Tab to focus, Esc to dismiss), absolutely positioned so it never reflows tight layouts.
- All copy lives in `src/components/help/glossary.ts` keyed by slug — adding a new term is a one-line change.
- No new dependencies; uses existing CSS variables.

## Where dots were placed (per issue scope)
- **Item detail header** (`/inventory/[id]`): `StatusPill` gains `showHelp` flag and renders a contextual dot for the current status (sourced/listed/sold/shipped); separate dot next to the Bought/Own chip.
- **New-item form** (`/inventory/new`): dots on "Where did this come from?" (bought-vs-own), Cost price, Status, Vinted URL.
- **Inventory filters bar**: dot on the Status label.

Repeating list rows don't get dots — the detail page is the first-time-user landing for term context, keeping the inventory table dense.

Glossary terms covered: `sourced`, `listed`, `sold`, `shipped`, `bought-vs-own`, `vinted-url`, `cost-price`, `status`. No `fees` entry (Vinted has none — per AGENTS.md).

## Test plan
- [ ] Hover and Tab to each dot — tooltip appears, Esc dismisses
- [ ] 1280×800 viewport: inventory list, new-item form, item detail still fit without page scroll
- [ ] Screen reader announces "More about {term}" and reads the tooltip body via `aria-describedby`
- [ ] Dark theme contrast is legible on `--surface-card` background

🤖 Generated with [Claude Code](https://claude.com/claude-code)